### PR TITLE
linux: Fix build for new OE versions

### DIFF
--- a/recipes-bsp/linux/linux-vuplus-3.13.5.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.13.5.inc
@@ -18,9 +18,9 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KV}.tar.bz2 \
 	file://${MACHINE}_defconfig \
 	"
 
-S = "${WORKDIR}/linux"
-
 inherit kernel machine_kernel_pr
+
+S = "${WORKDIR}/linux"
 
 export OS = "Linux"
 KERNEL_IMAGETYPE = "vmlinux"
@@ -31,8 +31,7 @@ KERNEL_IMAGEDEST = "/tmp"
 FILES_kernel-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz"
 
 do_configure_prepend() {
-	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${S}/.config
-	oe_runmake oldconfig
+	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig
 }
 
 kernel_do_install_append() {

--- a/recipes-bsp/linux/linux-vuplus-3.9.6.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.9.6.inc
@@ -18,9 +18,9 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KV}.tar.bz2 \
 	file://${MACHINE}_defconfig \
 	"
 
-S = "${WORKDIR}/linux"
-
 inherit kernel machine_kernel_pr
+
+S = "${WORKDIR}/linux"
 
 export OS = "Linux"
 KERNEL_IMAGETYPE = "vmlinux"
@@ -31,8 +31,7 @@ KERNEL_IMAGEDEST = "/tmp"
 FILES_kernel-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz"
 
 do_configure_prepend() {
-	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${S}/.config
-	oe_runmake oldconfig
+	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig
 }
 
 kernel_do_install_append() {


### PR DESCRIPTION
The kernel build recipes have undergone massive changes in newer
OpenEmbedded versions. This results in build failures like this:

| make: *** No rule to make target `oldconfig'.  Stop.

To resolve the issue, move the assignment of "S" to after the
"inherit kernel" statement, and remove the manual defconfig
handling, OE already takes care of that.