### PR TITLE
Remove "gst-ffmpeg" dependency

### DIFF
--- a/conf/machine/include/vuxxo.inc
+++ b/conf/machine/include/vuxxo.inc
@@ -3,7 +3,6 @@ MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = " \
 	vuplus-dvb-modules-${MACHINE} \
-	gst-ffmpeg \
 "
 
 KERNEL_MODULE_AUTOLOAD += "xfs"

--- a/conf/machine/include/vuxxo2.inc
+++ b/conf/machine/include/vuxxo2.inc
@@ -3,7 +3,6 @@ MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = " \
 	vuplus-dvb-modules-${MACHINE} \
-	gst-ffmpeg \
 "
 
 KERNEL_MODULE_AUTOLOAD += "xfs"

--- a/conf/machine/include/vuxxo4k.inc
+++ b/conf/machine/include/vuxxo4k.inc
@@ -3,7 +3,6 @@ MACHINE_FEATURES_BACKFILL_CONSIDERED = "rtc"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = " \
 	${@base_contains("MACHINE_FEATURES", "dvbproxy", "vuplus-dvb-proxy-${MACHINE} libgles-${MACHINE} vuplus-platform-util-${MACHINE}", "vuplus-dvb-modules-${MACHINE}", d)} \
-	gst-ffmpeg \
 "
 
 KERNEL_MODULE_AUTOLOAD += "xfs"


### PR DESCRIPTION
The gst-ffmpeg is not actually required and causes all of gstreamer 0.10 to
be built and dragged into the image, even when building with gstreamer 1.x.

Signed-off-by: Mike Looijmans <milo@openpli.org>