### PR TITLE
solo4k: make sure kernel shared workdir exists before configuring dvb…

### DIFF
--- a/recipes-bsp/drivers/vuplus-dvb-proxy.inc
+++ b/recipes-bsp/drivers/vuplus-dvb-proxy.inc
@@ -12,6 +12,7 @@ S = "${WORKDIR}"
 
 #inherit module-base
 DEPENDS = "virtual/kernel"
+do_configure[depends] += "virtual/kernel:do_shared_workdir"
 KERNEL_VERSION = "${@base_read_file('${STAGING_KERNEL_BUILDDIR}/kernel-abiversion')}"
 
 do_install() {


### PR DESCRIPTION
…-proxy

We need the kernel to be staged (unpacked, patched and configured) before
we can configure dvb-proxy because it requires file ${STAGING_KERNEL_BUILDDIR}/kernel-abiversion
and that file is not populated then kernel modules placed on wrong directory.