### PR TITLE
Changes to support current openembedded master

### DIFF
--- a/recipes-bsp/linux/linux-vuplus-3.13.5.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.13.5.inc
@@ -33,6 +33,7 @@ S = "${WORKDIR}/linux"
 export OS = "Linux"
 KERNEL_IMAGETYPE = "vmlinux"
 KERNEL_OUTPUT = "vmlinux"
+KERNEL_OUTPUT_DIR = "."
 KERNEL_OBJECT_SUFFIX = "ko"
 KERNEL_IMAGEDEST = "/tmp"
 

--- a/recipes-bsp/linux/linux-vuplus-3.9.6.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.9.6.inc
@@ -34,6 +34,7 @@ S = "${WORKDIR}/linux"
 export OS = "Linux"
 KERNEL_IMAGETYPE = "vmlinux"
 KERNEL_OUTPUT = "vmlinux"
+KERNEL_OUTPUT_DIR = "."
 KERNEL_OBJECT_SUFFIX = "ko"
 KERNEL_IMAGEDEST = "/tmp"
 


### PR DESCRIPTION
Required for OpenPLi-5

KERNEL_OUTPUT_DIR defaults to arch/${ARCH}/boot, which isn't where
these kernels end up. Previously this was done with KERNEL_OUTPUT,
but now that the kernel class supports multiple recipes, setting
KERNEL_OUTPUT_DIR to "./" fixes the kernel recipes no longer
building.