### PR TITLE
bluetoothsetup: Don't preserve ownership when installing files.

### DIFF
--- a/recipes-bsp/drivers/enigma2-plugin-systemplugins-bluetoothsetup.bb
+++ b/recipes-bsp/drivers/enigma2-plugin-systemplugins-bluetoothsetup.bb
@@ -23,7 +23,7 @@ do_compile() {
 
 do_install() {
 	install -d  ${D}${BLUETOOTH_PLUGIN_PATH}
-	cp -rp ${S}/* ${D}${BLUETOOTH_PLUGIN_PATH}
+	cp -r --preserve=mode,links ${S}/* ${D}${BLUETOOTH_PLUGIN_PATH}
 }
 
 FILES_${PN} = "${BLUETOOTH_PLUGIN_PATH}"


### PR DESCRIPTION
Pass "--preserve=mode,links" to the "cp" command instead of "-p".
This prevents the [host-user-contaminated] QA warnings from OE.

Thanks milo@openpli.org