### PR TITLE
linux-vuplus: change licence to GPLv2 to prevent warnings

### DIFF
--- a/recipes-bsp/linux/linux-vuplus-3.13.5.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.13.5.inc
@@ -1,5 +1,5 @@
 DESCRIPTION = "Linux kernel for ${MACHINE}"
-LICENSE = "GPL"
+LICENSE = "GPLv2"
 SECTION = "kernel"
 KV = "3.13.5"
 PR_INC = ".6"

--- a/recipes-bsp/linux/linux-vuplus-3.9.6.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.9.6.inc
@@ -1,5 +1,5 @@
 DESCRIPTION = "Linux kernel for ${MACHINE}"
-LICENSE = "GPL"
+LICENSE = "GPLv2"
 SECTION = "kernel"
 KV = "3.9.6"
 PR_INC = ".5"


### PR DESCRIPTION
It prevent the following warnings:
WARNING: openpli-enigma2-image-1.0-r0 do_image_complete: The license listed GPL was not in the licenses collected for recipe linux-vuultimo

Newer linux-vuplus 3.14 already has the correct licence.