### PR TITLE
webkit: add recipes to allow build hbbtv

### DIFF
--- a/recipes-bsp/webkit-hbbtv/enigma2-plugin-extensions-webkithbbtv.bb
+++ b/recipes-bsp/webkit-hbbtv/enigma2-plugin-extensions-webkithbbtv.bb
@@ -1,0 +1,33 @@
+DESCRIPTION = "E2 HbbTV Plugin"
+SECTION = "base"
+PRIORITY = "required"
+LICENSE = "CLOSED"
+#require conf/license/license-close.inc
+
+RDEPENDS_${PN} = "vuplus-webkithbbtv-dumpait webkit-hbbtv-browser libupnp"
+
+PV = "1.1"
+PR = "20170105.r0"
+SRC_URI = "http://archive.vuplus.com/download/build_support/webkit-hbbtv-plugin_${PR}.tar.gz"
+
+S = "${WORKDIR}"
+
+do_install_append() {
+    install -d ${D}/usr/bin
+    install -d ${D}/usr/lib/enigma2/python/Plugins/Extensions/WebkitHbbTV
+
+    install -m 0755 ${WORKDIR}/webkit-hbbtv-plugin/run-webkit.sh ${D}/usr/bin
+    cp -aRf ${WORKDIR}/webkit-hbbtv-plugin/WebkitHbbTV/* ${D}/usr/lib/enigma2/python/Plugins/Extensions/WebkitHbbTV/
+}
+
+do_package_qa() {
+}
+
+PROVIDES += "enigma2-plugin-extensions-webkithbbtv"
+RPROVIDES_${PN} += "enigma2-plugin-extensions-webkithbbtv"
+
+FILES_${PN} = "/"
+
+
+SRC_URI[md5sum] = "8b93c2f013934658daa2162cf58e3b71"
+SRC_URI[sha256sum] = "b6322cbfc06abe19052cfff0ae1f76d00d6a6f185fdc09fd10085823f9203c26"

--- a/recipes-bsp/webkit-hbbtv/vuplus-webkithbbtv-dumpait.bb
+++ b/recipes-bsp/webkit-hbbtv/vuplus-webkithbbtv-dumpait.bb
@@ -1,0 +1,29 @@
+SUMMARY = "dumpait"
+PRIORITY = "required"
+LICENSE = "GPLv3"
+LIC_FILES_CHKSUM = "file://LICENSE.GPLv3;md5=5ed852a46d22220a8b07a68e564d84c7"
+
+inherit autotools-brokensep pkgconfig gitpkgv
+
+SRCREV = "${AUTOREV}"
+PV = "git${SRCPV}"
+PKGV = "git${GITPKGV}"
+PR = "r0"
+
+PACKAGES += " ${PN}-src"
+
+DEPENDS = "libdvbsi++"
+
+SRC_URI = "git://code.vuplus.com/git/dumpait.git;protocol=http"
+
+S = "${WORKDIR}/git"
+DESTDIR = "enigma2/python/Plugins/Extensions/WebkitHbbTV"
+
+do_install() {
+    install -d ${D}/usr/lib/${DESTDIR}
+    install -m 0755 ${S}/src/dumpait ${D}/usr/lib/${DESTDIR}
+}
+
+FILES_${PN} = "${libdir}/${DESTDIR}/dumpait"
+FILES_${PN}-dbg = "${libdir}/${DESTDIR}/.debug"
+FILES_${PN}-src = "/usr/src"

--- a/recipes-bsp/webkit-hbbtv/webkit-hbbtv-browser-vusolo4k.bb
+++ b/recipes-bsp/webkit-hbbtv/webkit-hbbtv-browser-vusolo4k.bb
@@ -1,0 +1,9 @@
+SRCDATE = "20170324.r0"
+
+require webkit-hbbtv-browser.inc
+
+COMPATIBLE_MACHINE = "^(vusolo4k)$"
+
+
+SRC_URI[md5sum] = "44ef1594ac1ea01344e70602ce4a24ee"
+SRC_URI[sha256sum] = "fbd93d672e25d0e4a341d25b0089f94ee92a010c2102eb415347e6e1f3736f46"

--- a/recipes-bsp/webkit-hbbtv/webkit-hbbtv-browser-vuultimo4k.bb
+++ b/recipes-bsp/webkit-hbbtv/webkit-hbbtv-browser-vuultimo4k.bb
@@ -1,0 +1,9 @@
+SRCDATE = "20170324.r0"
+
+require webkit-hbbtv-browser.inc
+
+COMPATIBLE_MACHINE = "^(vuultimo4k)$"
+
+
+SRC_URI[md5sum] = "d310a2beeda59a1f0783dfff74690bea"
+SRC_URI[sha256sum] = "aef08a79f55426ab10268b83a36e4778bd46752791ef9ba31f25a622bf59d4f6"

--- a/recipes-bsp/webkit-hbbtv/webkit-hbbtv-browser-vuuno4k.bb
+++ b/recipes-bsp/webkit-hbbtv/webkit-hbbtv-browser-vuuno4k.bb
@@ -1,0 +1,9 @@
+SRCDATE = "20170324.r0"
+
+require webkit-hbbtv-browser.inc
+
+COMPATIBLE_MACHINE = "^(vuuno4k)$"
+
+
+SRC_URI[md5sum] = "6f6e621aae41cfe6c7a1ac07524415a1"
+SRC_URI[sha256sum] = "b7e408dc8996f75b69d32cd8b0f626031764986e1869415e845ab008928ef2a8"

--- a/recipes-bsp/webkit-hbbtv/webkit-hbbtv-browser.inc
+++ b/recipes-bsp/webkit-hbbtv/webkit-hbbtv-browser.inc
@@ -1,0 +1,44 @@
+DESCRIPTION = "Webkit browser for HbbTV"
+SECTION = "base"
+PRIORITY = "required"
+LICENSE = "CLOSED"
+#require conf/license/license-close.inc
+
+PV = "1.1"
+PR = "${SRCDATE}"
+SRC_URI = "http://archive.vuplus.com/download/build_support/webkit-hbbtv-browser_${MACHINE}_${SRCDATE}.tar.gz"
+
+RDEPENDS_${PN} = "webkit-gtk libudev"
+
+do_install_append() {
+	install -d ${D}/usr/bin
+	install -d ${D}/usr/lib/mozilla/plugins
+	install -d ${D}/home/root
+
+	install -m 0755 ${WORKDIR}/webkit-hbbtv-browser/none.html ${D}/home/root
+	install -m 0755 ${WORKDIR}/webkit-hbbtv-browser/browser ${D}/usr/bin
+	install -m 0755 ${WORKDIR}/webkit-hbbtv-browser/libhbbtvplugin.so ${D}/usr/lib/mozilla/plugins/
+
+	# patch browser for libudev.so.1
+	sed -i 's/libudev.so.0/libudev.so.1/g' ${D}/usr/bin/browser
+}
+
+do_package_qa() {
+}
+
+#pkg_postinst_${PN} () {
+#	if [ -z "$D" ]; then
+#		if [ ! -f /lib/libudev.so.0 ]; then
+#			ln -s /lib/libudev.so.1 /lib/libudev.so.0
+#		fi
+#	fi
+#}
+
+PROVIDES += "webkit-hbbtv-browser"
+RPROVIDES_${PN} += "webkit-hbbtv-browser"
+
+PACKAGE_ARCH := "${MACHINE_ARCH}"
+
+FILES_${PN} = "/"
+
+INSANE_SKIP_${PN} += "already-stripped"

--- a/recipes-webkit/webkit/files/0001-bison-3.patch
+++ b/recipes-webkit/webkit/files/0001-bison-3.patch
@@ -1,0 +1,577 @@
+From f1ca15c0547a19a0781c13f6b3303305a898096e Mon Sep 17 00:00:00 2001
+From: captain <openatv@gmail.com>
+Date: Tue, 20 Sep 2016 21:57:27 +0200
+Subject: [PATCH] bison-3
+
+---
+ Source/ThirdParty/ANGLE/src/compiler/glslang.y |   1 +
+ Source/WebCore/css/CSSGrammar.y                |  11 +-
+ Source/WebCore/css/CSSParser.cpp               |   2 +-
+ Source/WebCore/xml/XPathGrammar.y              | 182 ++++++++++++-------------
+ Source/WebCore/xml/XPathParser.cpp             |  15 +-
+ 5 files changed, 104 insertions(+), 107 deletions(-)
+
+diff --git a/Source/ThirdParty/ANGLE/src/compiler/glslang.y b/Source/ThirdParty/ANGLE/src/compiler/glslang.y
+index d05f441..f3b352d 100644
+--- a/Source/ThirdParty/ANGLE/src/compiler/glslang.y
++++ b/Source/ThirdParty/ANGLE/src/compiler/glslang.y
+@@ -32,6 +32,7 @@ WHICH GENERATES THE GLSL ES PARSER (glslang_tab.cpp AND glslang_tab.h).
+ %expect 1 /* One shift reduce conflict because of if | else */
+ %pure-parser
+ %parse-param {TParseContext* context}
++%lex-param {YYLEX_PARAM}
+ 
+ %union {
+     struct {
+diff --git a/Source/WebCore/css/CSSGrammar.y b/Source/WebCore/css/CSSGrammar.y
+index 90b5e14..7c79c90 100644
+--- a/Source/WebCore/css/CSSGrammar.y
++++ b/Source/WebCore/css/CSSGrammar.y
+@@ -53,13 +53,12 @@ using namespace HTMLNames;
+ #define YYMAXDEPTH 10000
+ #define YYDEBUG 0
+ 
+-// FIXME: Replace with %parse-param { CSSParser* parser } once we can depend on bison 2.x
+-#define YYPARSE_PARAM parser
+-#define YYLEX_PARAM parser
+-
+ %}
+ 
+-%pure_parser
++%pure-parser
++
++%parse-param { CSSParser* parser }
++%lex-param { CSSParser* parser }
+ 
+ %union {
+     bool boolean;
+@@ -88,7 +87,7 @@ using namespace HTMLNames;
+ 
+ %{
+ 
+-static inline int cssyyerror(const char*)
++static inline int cssyyerror(void*, const char*)
+ {
+     return 1;
+ }
+diff --git a/Source/WebCore/css/CSSParser.cpp b/Source/WebCore/css/CSSParser.cpp
+index 4e68010..4646869 100644
+--- a/Source/WebCore/css/CSSParser.cpp
++++ b/Source/WebCore/css/CSSParser.cpp
+@@ -90,7 +90,7 @@
+ extern int cssyydebug;
+ #endif
+ 
+-extern int cssyyparse(void* parser);
++extern int cssyyparse(WebCore::CSSParser*);
+ 
+ using namespace std;
+ using namespace WTF;
+diff --git a/Source/WebCore/xml/XPathGrammar.y b/Source/WebCore/xml/XPathGrammar.y
+index 14e9fa3..28a670e 100644
+--- a/Source/WebCore/xml/XPathGrammar.y
++++ b/Source/WebCore/xml/XPathGrammar.y
+@@ -36,6 +36,7 @@
+ #include "XPathParser.h"
+ #include "XPathPath.h"
+ #include "XPathPredicate.h"
++#include "XPathStep.h"
+ #include "XPathVariableReference.h"
+ #include <wtf/FastMalloc.h>
+ 
+@@ -46,15 +47,14 @@
+ #define YYLTYPE_IS_TRIVIAL 1
+ #define YYDEBUG 0
+ #define YYMAXDEPTH 10000
+-#define YYPARSE_PARAM parserParameter
+-#define PARSER static_cast<Parser*>(parserParameter)
+ 
+ using namespace WebCore;
+ using namespace XPath;
+ 
+ %}
+ 
+-%pure_parser
++%pure-parser
++%parse-param { WebCore::XPath::Parser* parser }
+ 
+ %union
+ {
+@@ -73,7 +73,7 @@ using namespace XPath;
+ %{
+ 
+ static int xpathyylex(YYSTYPE* yylval) { return Parser::current()->lex(yylval); }
+-static void xpathyyerror(const char*) { }
++static void xpathyyerror(void*, const char*) { }
+     
+ %}
+ 
+@@ -120,7 +120,7 @@ static void xpathyyerror(const char*) { }
+ Expr:
+     OrExpr
+     {
+-        PARSER->m_topExpr = $1;
++        parser->m_topExpr = $1;
+     }
+     ;
+ 
+@@ -140,7 +140,7 @@ AbsoluteLocationPath:
+     '/'
+     {
+         $$ = new LocationPath;
+-        PARSER->registerParseNode($$);
++        parser->registerParseNode($$);
+     }
+     |
+     '/' RelativeLocationPath
+@@ -152,7 +152,7 @@ AbsoluteLocationPath:
+     {
+         $$ = $2;
+         $$->insertFirstStep($1);
+-        PARSER->unregisterParseNode($1);
++        parser->unregisterParseNode($1);
+     }
+     ;
+ 
+@@ -161,22 +161,22 @@ RelativeLocationPath:
+     {
+         $$ = new LocationPath;
+         $$->appendStep($1);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($1);
++        parser->registerParseNode($$);
+     }
+     |
+     RelativeLocationPath '/' Step
+     {
+         $$->appendStep($3);
+-        PARSER->unregisterParseNode($3);
++        parser->unregisterParseNode($3);
+     }
+     |
+     RelativeLocationPath DescendantOrSelf Step
+     {
+         $$->appendStep($2);
+         $$->appendStep($3);
+-        PARSER->unregisterParseNode($2);
+-        PARSER->unregisterParseNode($3);
++        parser->unregisterParseNode($2);
++        parser->unregisterParseNode($3);
+     }
+     ;
+ 
+@@ -185,58 +185,58 @@ Step:
+     {
+         if ($2) {
+             $$ = new Step(Step::ChildAxis, *$1, *$2);
+-            PARSER->deletePredicateVector($2);
++            parser->deletePredicateVector($2);
+         } else
+             $$ = new Step(Step::ChildAxis, *$1);
+-        PARSER->deleteNodeTest($1);
+-        PARSER->registerParseNode($$);
++        parser->deleteNodeTest($1);
++        parser->registerParseNode($$);
+     }
+     |
+     NAMETEST OptionalPredicateList
+     {
+         String localName;
+         String namespaceURI;
+-        if (!PARSER->expandQName(*$1, localName, namespaceURI)) {
+-            PARSER->m_gotNamespaceError = true;
++        if (!parser->expandQName(*$1, localName, namespaceURI)) {
++            parser->m_gotNamespaceError = true;
+             YYABORT;
+         }
+         
+         if ($2) {
+             $$ = new Step(Step::ChildAxis, Step::NodeTest(Step::NodeTest::NameTest, localName, namespaceURI), *$2);
+-            PARSER->deletePredicateVector($2);
++            parser->deletePredicateVector($2);
+         } else
+             $$ = new Step(Step::ChildAxis, Step::NodeTest(Step::NodeTest::NameTest, localName, namespaceURI));
+-        PARSER->deleteString($1);
+-        PARSER->registerParseNode($$);
++        parser->deleteString($1);
++        parser->registerParseNode($$);
+     }
+     |
+     AxisSpecifier NodeTest OptionalPredicateList
+     {
+         if ($3) {
+             $$ = new Step($1, *$2, *$3);
+-            PARSER->deletePredicateVector($3);
++            parser->deletePredicateVector($3);
+         } else
+             $$ = new Step($1, *$2);
+-        PARSER->deleteNodeTest($2);
+-        PARSER->registerParseNode($$);
++        parser->deleteNodeTest($2);
++        parser->registerParseNode($$);
+     }
+     |
+     AxisSpecifier NAMETEST OptionalPredicateList
+     {
+         String localName;
+         String namespaceURI;
+-        if (!PARSER->expandQName(*$2, localName, namespaceURI)) {
+-            PARSER->m_gotNamespaceError = true;
++        if (!parser->expandQName(*$2, localName, namespaceURI)) {
++            parser->m_gotNamespaceError = true;
+             YYABORT;
+         }
+ 
+         if ($3) {
+             $$ = new Step($1, Step::NodeTest(Step::NodeTest::NameTest, localName, namespaceURI), *$3);
+-            PARSER->deletePredicateVector($3);
++            parser->deletePredicateVector($3);
+         } else
+             $$ = new Step($1, Step::NodeTest(Step::NodeTest::NameTest, localName, namespaceURI));
+-        PARSER->deleteString($2);
+-        PARSER->registerParseNode($$);
++        parser->deleteString($2);
++        parser->registerParseNode($$);
+     }
+     |
+     AbbreviatedStep
+@@ -261,23 +261,23 @@ NodeTest:
+         else if (*$1 == "comment")
+             $$ = new Step::NodeTest(Step::NodeTest::CommentNodeTest);
+ 
+-        PARSER->deleteString($1);
+-        PARSER->registerNodeTest($$);
++        parser->deleteString($1);
++        parser->registerNodeTest($$);
+     }
+     |
+     PI '(' ')'
+     {
+         $$ = new Step::NodeTest(Step::NodeTest::ProcessingInstructionNodeTest);
+-        PARSER->deleteString($1);        
+-        PARSER->registerNodeTest($$);
++        parser->deleteString($1);
++        parser->registerNodeTest($$);
+     }
+     |
+     PI '(' LITERAL ')'
+     {
+         $$ = new Step::NodeTest(Step::NodeTest::ProcessingInstructionNodeTest, $3->stripWhiteSpace());
+-        PARSER->deleteString($1);        
+-        PARSER->deleteString($3);
+-        PARSER->registerNodeTest($$);
++        parser->deleteString($1);
++        parser->deleteString($3);
++        parser->registerNodeTest($$);
+     }
+     ;
+ 
+@@ -295,14 +295,14 @@ PredicateList:
+     {
+         $$ = new Vector<Predicate*>;
+         $$->append(new Predicate($1));
+-        PARSER->unregisterParseNode($1);
+-        PARSER->registerPredicateVector($$);
++        parser->unregisterParseNode($1);
++        parser->registerPredicateVector($$);
+     }
+     |
+     PredicateList Predicate
+     {
+         $$->append(new Predicate($2));
+-        PARSER->unregisterParseNode($2);
++        parser->unregisterParseNode($2);
+     }
+     ;
+ 
+@@ -317,7 +317,7 @@ DescendantOrSelf:
+     SLASHSLASH
+     {
+         $$ = new Step(Step::DescendantOrSelfAxis, Step::NodeTest(Step::NodeTest::AnyNodeTest));
+-        PARSER->registerParseNode($$);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+@@ -325,13 +325,13 @@ AbbreviatedStep:
+     '.'
+     {
+         $$ = new Step(Step::SelfAxis, Step::NodeTest(Step::NodeTest::AnyNodeTest));
+-        PARSER->registerParseNode($$);
++        parser->registerParseNode($$);
+     }
+     |
+     DOTDOT
+     {
+         $$ = new Step(Step::ParentAxis, Step::NodeTest(Step::NodeTest::AnyNodeTest));
+-        PARSER->registerParseNode($$);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+@@ -339,8 +339,8 @@ PrimaryExpr:
+     VARIABLEREFERENCE
+     {
+         $$ = new VariableReference(*$1);
+-        PARSER->deleteString($1);
+-        PARSER->registerParseNode($$);
++        parser->deleteString($1);
++        parser->registerParseNode($$);
+     }
+     |
+     '(' Expr ')'
+@@ -351,15 +351,15 @@ PrimaryExpr:
+     LITERAL
+     {
+         $$ = new StringExpression(*$1);
+-        PARSER->deleteString($1);
+-        PARSER->registerParseNode($$);
++        parser->deleteString($1);
++        parser->registerParseNode($$);
+     }
+     |
+     NUMBER
+     {
+         $$ = new Number($1->toDouble());
+-        PARSER->deleteString($1);
+-        PARSER->registerParseNode($$);
++        parser->deleteString($1);
++        parser->registerParseNode($$);
+     }
+     |
+     FunctionCall
+@@ -371,8 +371,8 @@ FunctionCall:
+         $$ = createFunction(*$1);
+         if (!$$)
+             YYABORT;
+-        PARSER->deleteString($1);
+-        PARSER->registerParseNode($$);
++        parser->deleteString($1);
++        parser->registerParseNode($$);
+     }
+     |
+     FUNCTIONNAME '(' ArgumentList ')'
+@@ -380,9 +380,9 @@ FunctionCall:
+         $$ = createFunction(*$1, *$3);
+         if (!$$)
+             YYABORT;
+-        PARSER->deleteString($1);
+-        PARSER->deleteExpressionVector($3);
+-        PARSER->registerParseNode($$);
++        parser->deleteString($1);
++        parser->deleteExpressionVector($3);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+@@ -391,14 +391,14 @@ ArgumentList:
+     {
+         $$ = new Vector<Expression*>;
+         $$->append($1);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->registerExpressionVector($$);
++        parser->unregisterParseNode($1);
++        parser->registerExpressionVector($$);
+     }
+     |
+     ArgumentList ',' Argument
+     {
+         $$->append($3);
+-        PARSER->unregisterParseNode($3);
++        parser->unregisterParseNode($3);
+     }
+     ;
+ 
+@@ -414,9 +414,9 @@ UnionExpr:
+         $$ = new Union;
+         $$->addSubExpression($1);
+         $$->addSubExpression($3);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->unregisterParseNode($3);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($1);
++        parser->unregisterParseNode($3);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+@@ -432,9 +432,9 @@ PathExpr:
+     {
+         $3->setAbsolute(true);
+         $$ = new Path(static_cast<Filter*>($1), $3);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->unregisterParseNode($3);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($1);
++        parser->unregisterParseNode($3);
++        parser->registerParseNode($$);
+     }
+     |
+     FilterExpr DescendantOrSelf RelativeLocationPath
+@@ -442,10 +442,10 @@ PathExpr:
+         $3->insertFirstStep($2);
+         $3->setAbsolute(true);
+         $$ = new Path(static_cast<Filter*>($1), $3);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->unregisterParseNode($2);
+-        PARSER->unregisterParseNode($3);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($1);
++        parser->unregisterParseNode($2);
++        parser->unregisterParseNode($3);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+@@ -455,9 +455,9 @@ FilterExpr:
+     PrimaryExpr PredicateList
+     {
+         $$ = new Filter($1, *$2);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->deletePredicateVector($2);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($1);
++        parser->deletePredicateVector($2);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+@@ -467,9 +467,9 @@ OrExpr:
+     OrExpr OR AndExpr
+     {
+         $$ = new LogicalOp(LogicalOp::OP_Or, $1, $3);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->unregisterParseNode($3);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($1);
++        parser->unregisterParseNode($3);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+@@ -479,9 +479,9 @@ AndExpr:
+     AndExpr AND EqualityExpr
+     {
+         $$ = new LogicalOp(LogicalOp::OP_And, $1, $3);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->unregisterParseNode($3);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($1);
++        parser->unregisterParseNode($3);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+@@ -491,9 +491,9 @@ EqualityExpr:
+     EqualityExpr EQOP RelationalExpr
+     {
+         $$ = new EqTestOp($2, $1, $3);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->unregisterParseNode($3);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($1);
++        parser->unregisterParseNode($3);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+@@ -503,9 +503,9 @@ RelationalExpr:
+     RelationalExpr RELOP AdditiveExpr
+     {
+         $$ = new EqTestOp($2, $1, $3);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->unregisterParseNode($3);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($1);
++        parser->unregisterParseNode($3);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+@@ -515,17 +515,17 @@ AdditiveExpr:
+     AdditiveExpr PLUS MultiplicativeExpr
+     {
+         $$ = new NumericOp(NumericOp::OP_Add, $1, $3);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->unregisterParseNode($3);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($1);
++        parser->unregisterParseNode($3);
++        parser->registerParseNode($$);
+     }
+     |
+     AdditiveExpr MINUS MultiplicativeExpr
+     {
+         $$ = new NumericOp(NumericOp::OP_Sub, $1, $3);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->unregisterParseNode($3);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($1);
++        parser->unregisterParseNode($3);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+@@ -535,9 +535,9 @@ MultiplicativeExpr:
+     MultiplicativeExpr MULOP UnaryExpr
+     {
+         $$ = new NumericOp($2, $1, $3);
+-        PARSER->unregisterParseNode($1);
+-        PARSER->unregisterParseNode($3);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($1);
++        parser->unregisterParseNode($3);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+@@ -548,8 +548,8 @@ UnaryExpr:
+     {
+         $$ = new Negative;
+         $$->addSubExpression($2);
+-        PARSER->unregisterParseNode($2);
+-        PARSER->registerParseNode($$);
++        parser->unregisterParseNode($2);
++        parser->registerParseNode($$);
+     }
+     ;
+ 
+diff --git a/Source/WebCore/xml/XPathParser.cpp b/Source/WebCore/xml/XPathParser.cpp
+index ba6da7e..80517e3 100644
+--- a/Source/WebCore/xml/XPathParser.cpp
++++ b/Source/WebCore/xml/XPathParser.cpp
+@@ -34,24 +34,21 @@
+ #include "XPathEvaluator.h"
+ #include "XPathException.h"
+ #include "XPathNSResolver.h"
++#include "XPathPath.h"
+ #include "XPathStep.h"
+ #include <wtf/StdLibExtras.h>
+ #include <wtf/text/StringHash.h>
+ 
+-int xpathyyparse(void*);
+-
++using namespace WebCore;
+ using namespace WTF;
+ using namespace Unicode;
++using namespace XPath;
+ 
+-namespace WebCore {
+-namespace XPath {
+-
+-class LocationPath;
+-
+-#include "XPathGrammar.h"    
++extern int xpathyyparse(WebCore::XPath::Parser*);
++#include "XPathGrammar.h"
+ 
+ Parser* Parser::currentParser = 0;
+-    
++
+ enum XMLCat { NameStart, NameCont, NotPartOfName };
+ 
+ typedef HashMap<String, Step::Axis> AxisNamesMap;
+-- 
+2.9.2.windows.1
+

--- a/recipes-webkit/webkit/files/0001-fix-build-issue-with-cglib-2.2.4.patch
+++ b/recipes-webkit/webkit/files/0001-fix-build-issue-with-cglib-2.2.4.patch
@@ -1,0 +1,27 @@
+From a4a6743cc5c1189e051c20282067ab4258aaff5d Mon Sep 17 00:00:00 2001
+From: captain <openatv@gmail.com>
+Date: Tue, 20 Sep 2016 23:10:22 +0200
+Subject: [PATCH] fix build issue with cglib 2.2.4
+
+---
+ Source/WebCore/platform/gtk/GtkClickCounter.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Source/WebCore/platform/gtk/GtkClickCounter.cpp b/Source/WebCore/platform/gtk/GtkClickCounter.cpp
+index acc8a32..3bef95f 100644
+--- a/Source/WebCore/platform/gtk/GtkClickCounter.cpp
++++ b/Source/WebCore/platform/gtk/GtkClickCounter.cpp
+@@ -85,8 +85,8 @@ int GtkClickCounter::clickCountForGdkButtonEvent(GtkWidget* widget, GdkEventButt
+     guint32 eventTime = getEventTime(event);
+ 
+     if ((event->type == GDK_2BUTTON_PRESS || event->type == GDK_3BUTTON_PRESS)
+-        || ((abs(buttonEvent->x - m_previousClickPoint.x()) < doubleClickDistance)
+-            && (abs(buttonEvent->y - m_previousClickPoint.y()) < doubleClickDistance)
++        || ((fabs(buttonEvent->x - m_previousClickPoint.x()) < doubleClickDistance)
++            && (fabs(buttonEvent->y - m_previousClickPoint.y()) < doubleClickDistance)
+             && (eventTime - m_previousClickTime < static_cast<guint>(doubleClickTime))
+             && (buttonEvent->button == m_previousClickButton)))
+         m_currentClickCount++;
+-- 
+2.9.2.windows.1
+

--- a/recipes-webkit/webkit/files/0001-fix-build-with-gcc-6.20.patch
+++ b/recipes-webkit/webkit/files/0001-fix-build-with-gcc-6.20.patch
@@ -1,0 +1,39 @@
+From 8426175c13a5c616b4e564eca1db692084a197c2 Mon Sep 17 00:00:00 2001
+From: captain <openatv@gmail.com>
+Date: Tue, 20 Sep 2016 22:40:31 +0200
+Subject: [PATCH] fix build with gcc 6.20
+
+---
+ configure    | 2 +-
+ configure.ac | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index 071e7f7..f11c92d 100755
+--- a/configure
++++ b/configure
+@@ -17974,7 +17974,7 @@ x$ax_compare_version_B" | sed 's/^ *//' | sort -r | sed "s/x${ax_compare_version
+ 
+ 
+     if test "$ax_compare_version" = "true" ; then
+-    CXXFLAGS="$CXXFLAGS -Wno-c++0x-compat"
++    CXXFLAGS="$CXXFLAGS -Wno-c++0x-compat -std=gnu++98"
+       fi
+ 
+ fi
+diff --git a/configure.ac b/configure.ac
+index e7c28f6..cd17a94 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -103,7 +103,7 @@ fi
+ # cleanly with that.
+ if test "$CXX" = "g++"; then
+    CXX_VERSION=`$CXX -dumpversion`
+-   AX_COMPARE_VERSION([$CXX_VERSION],[ge],[4.6.0],CXXFLAGS="$CXXFLAGS -Wno-c++0x-compat")
++   AX_COMPARE_VERSION([$CXX_VERSION],[ge],[4.6.0],CXXFLAGS="$CXXFLAGS -Wno-c++0x-compat -std=gnu++98")
+ fi
+ 
+ # pthread (not needed on Windows)
+-- 
+2.9.2.windows.1
+

--- a/recipes-webkit/webkit/files/maketokenizer.patch
+++ b/recipes-webkit/webkit/files/maketokenizer.patch
@@ -1,0 +1,12 @@
+diff --git a/Source/WebCore/css/maketokenizer b/Source/WebCore/css/maketokenizer
+index d2a786f..1aa17b5 100644
+--- a/Source/WebCore/css/maketokenizer
++++ b/Source/WebCore/css/maketokenizer
+@@ -112,6 +112,7 @@ while (<>) {
+ # Skip past initialization code, down to main loop.
+ while (<>) {
+     last if /while \( 1 \)/;
++    last if /while \( ..CONSTCOND..1 \)/;
+ }
+ 
+ # Dump the main loop, skipping over labels we don't use.

--- a/recipes-webkit/webkit/files/webkit-gtk_fixed_crash_error.patch
+++ b/recipes-webkit/webkit/files/webkit-gtk_fixed_crash_error.patch
@@ -1,0 +1,17 @@
+diff --git a/Source/WebCore/plugins/PluginView.cpp b/Source/WebCore/plugins/PluginView.cpp
+index c21fcd7..d6a3a85 100644
+--- a/Source/WebCore/plugins/PluginView.cpp
++++ b/Source/WebCore/plugins/PluginView.cpp
+@@ -126,7 +126,11 @@ IntRect PluginView::windowClipRect() const
+     IntRect clipRect(m_windowRect);
+     
+     // Take our element and get the clip rect from the enclosing layer and frame view.
+-    RenderLayer* layer = m_element->renderer()->enclosingLayer();
++    RenderLayer* layer = 0;
++    RenderObject* renderer = m_element->renderer();
++    if (renderer) {
++        layer = m_element->renderer()->enclosingLayer();
++    }
+     FrameView* parentView = m_element->document()->view();
+     clipRect.intersect(parentView->windowClipRectForLayer(layer, true));
+ 

--- a/recipes-webkit/webkit/webkit-gtk_git.bb
+++ b/recipes-webkit/webkit/webkit-gtk_git.bb
@@ -1,0 +1,95 @@
+SUMMARY = "WebKit web rendering engine for the GTK+ platform"
+HOMEPAGE = "http://www.webkitgtk.org/"
+BUGTRACKER = "http://bugs.webkit.org/"
+
+LICENSE = "BSD & LGPLv2+"
+LIC_FILES_CHKSUM = "\
+	file://Source/WebCore/rendering/RenderApplet.h;endline=22;md5=fb9694013ad71b78f8913af7a5959680 \
+	file://Source/WebKit/gtk/webkit/webkit.h;endline=21;md5=b4fbe9f4a944f1d071dba1d2c76b3351 \
+	file://Source/JavaScriptCore/parser/Parser.h;endline=23;md5=2f3cff0ad0a9c486da5a376928973a90 \
+	"
+
+DEPENDS = "glib-2.0 icu zlib enchant libsoup-2.4 curl libxml2 cairo libidn gnutls \
+           gtk+ gstreamer1.0 gstreamer1.0-plugins-base flex-native bison-native gperf-native sqlite3 \
+           libxslt zlib libpcre harfbuzz pango atk udev"
+
+PR = "r5"
+PV = "r95199"
+
+BRANCH="vuplus-webkit"
+SRCREV="9eed47d1f873a13759d3fd8ead72739b328d710a"
+
+SRC_URI = "git://code.vuplus.com:/git/webkit-r95199-base.git;protocol=http;branch=${BRANCH};rev=${SRCREV} \
+    file://0001-bison-3.patch \
+    file://0001-fix-build-with-gcc-6.20.patch \
+    file://0001-fix-build-issue-with-cglib-2.2.4.patch \
+    file://webkit-gtk_fixed_crash_error.patch \
+    file://maketokenizer.patch \
+"
+
+inherit autotools lib_package gtk-doc pkgconfig perlnative pythonnative
+
+S = "${WORKDIR}/git"
+
+EXTRA_OECONF = "\
+	--enable-debug=no \
+	--with-gtk=2.0 \
+	--disable-spellcheck \
+	--enable-optimizations \
+	--disable-channel-messaging \
+	--disable-meter-tag \
+	--enable-image-resizer \
+	--disable-sandbox \
+	--disable-xpath \
+	--disable-xslt \
+	--disable-svg \
+	--disable-filters \
+	--disable-svg-fonts \
+	--disable-video \
+	--disable-video-track \
+	--with-target=directfb \
+	--disable-jit \
+	--enable-fast-malloc \
+	--enable-shared-workers \
+	--enable-workers \
+	--enable-javascript-debugger \
+	--enable-fast-mobile-scrolling \
+	--enable-offline-web-applications \
+	"
+
+LDFLAGS += "-Wl,--no-keep-memory"
+
+CXXFLAGS += " -std=gnu++98"
+
+EXTRA_AUTORECONF = " -I Source/autotools "
+
+ARM_INSTRUCTION_SET = "arm"
+
+COMPATIBLE_HOST_mips64n32 = "null"
+
+CONFIGUREOPT_DEPTRACK = ""
+
+do_configure_append() {
+	# somethings wrong with icu, fix it up manually
+	for makefile in $(find ${B} -name "GNUmakefile") ; do
+		sed -i s:-I/usr/include::g $makefile
+	done
+	# remove hardcoded path to /usr/bin/glib-mkenums
+	for makefile in $(find ${B} -name "GNUmakefile") ; do
+		sed -i s:/usr/bin/glib-mkenums:glib-mkenums:g $makefile
+	done
+}
+
+do_install_append() {
+        rmdir ${D}${libexecdir}
+        install -d ${D}/usr/bin
+        install -m 0755 ${WORKDIR}/build/Programs/GtkLauncher ${D}/usr/bin/webkit.launcher
+}
+
+PACKAGES =+ "${PN}-webinspector bjavascriptcore"
+FILES_libjavascriptcore = "${libdir}/libjavascriptcoregtk-1.0.so.*"
+FILES_${PN}-webinspector = "${datadir}/webkitgtk-*/webinspector/"
+FILES_${PN} += "${datadir}/webkitgtk-*/resources/error.html \
+                ${datadir}/webkitgtk-*/images \
+                ${datadir}/glib-2.0/schemas"
+


### PR DESCRIPTION
The webkit-gtk includes additional patch to allow build with newer bison.
Also hardcoded path to glib-mkenums was removed, masked due to libglib2.0-dev installation.

There are additionall patches required for gtk+ and directfb, not covered by this commit.

Once the recipes are ready, build can be enabled by adding the following to vu*4k.conf

EXTRA_IMAGEDEPENDS += " \
        enigma2-plugin-extensions-webkithbbtv \
"