### PR TITLE
kodi: add missing PROVIDES on libgles to allow build kodi

### DIFF
--- a/conf/machine/include/vuxxo4k.inc
+++ b/conf/machine/include/vuxxo4k.inc
@@ -38,6 +38,9 @@ PREFERRED_PROVIDER_virtual/kernel = "linux-${MACHINE}"
 PREFERRED_PROVIDER_virtual/blindscan-dvbc = "vuplus-blindscan-utils-${MACHINE}"
 PREFERRED_PROVIDER_virtual/blindscan-dvbs = "vuplus-blindscan-utils-${MACHINE}"
 
+PREFERRED_PROVIDER_virtual/egl = "libgles-${MACHINE}"
+PREFERRED_PROVIDER_virtual/libgles2 = "libgles-${MACHINE}"
+
 IMAGE_FSTYPES ?= "tar.bz2"
 
 IMAGEDIR ?= "${MACHINE}"

--- a/recipes-bsp/drivers/libgles.inc
+++ b/recipes-bsp/drivers/libgles.inc
@@ -1,6 +1,9 @@
 SECTION = "base"
 LICENSE = "CLOSED"
 
+PROVIDES = "virtual/libgles2 virtual/egl"
+COMPATIBLE_MACHINE = "vu"
+
 PV="15.1"
 PR="${SRCDATE}.${SRCDATE_PR}"
 
@@ -21,7 +24,9 @@ do_install() {
 do_package_qa[noexec] = "1"
 
 PACKAGE_ARCH := "${MACHINE_ARCH}"
-PACKAGES = "${PN}"
-FILES_${PN}="/usr/lib /usr/include"
+FILES_SOLIBSDEV = ""
+FILES_${PN}="${libdir}"
+
+RPROVIDES_${PN} = "libEGL.so libGLESv2.so libdvb_base.so libdvb_client.so libnxpl.so libv3ddriver.so"
 
 INSANE_SKIP_${PN} = "already-stripped"


### PR DESCRIPTION
libgles now provides virtual/egl and virtual/libgles2 required by kodi.
Also the header files moved to dev package where they belong.