### PR TITLE
meta-vuplus: add compiler-gcc7.h in kernel tree.

### DIFF
--- a/recipes-bsp/linux/files/kernel-gcc7.patch
+++ b/recipes-bsp/linux/files/kernel-gcc7.patch
@@ -1,0 +1,69 @@
+diff --git a/include/linux/compiler-gcc7.h b/include/linux/compiler-gcc7.h
+new file mode 100644
+index 0000000..ba064fa
+--- /dev/null
++++ b/include/linux/compiler-gcc7.h
+@@ -0,0 +1,59 @@
++#ifndef __LINUX_COMPILER_H
++#error "Please don't include <linux/compiler-gcc7.h> directly, include <linux/compiler.h> instead."
++#endif
++
++#define __used				__attribute__((__used__))
++#define __must_check			__attribute__((warn_unused_result))
++#define __compiler_offsetof(a, b)	__builtin_offsetof(a, b)
++
++/* Mark functions as cold. gcc will assume any path leading to a call
++   to them will be unlikely.  This means a lot of manual unlikely()s
++   are unnecessary now for any paths leading to the usual suspects
++   like BUG(), printk(), panic() etc. [but let's keep them for now for
++   older compilers]
++
++   gcc also has a __attribute__((__hot__)) to move hot functions into
++   a special section, but I don't see any sense in this right now in
++   the kernel context */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible __attribute__((externally_visible))
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#define __HAVE_BUILTIN_BSWAP16__
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
++
++#define KASAN_ABI_VERSION 4
+-- 
+2.1.0
+
+  

--- a/recipes-bsp/linux/linux-vuplus-3.13.5.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.13.5.inc
@@ -23,6 +23,7 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KV}.tar.bz2 \
 	file://0001-STV-Add-SNR-Signal-report-parameters.patch \
 	file://0001-stv090x-optimized-TS-sync-control.patch \
 	file://kernel-gcc6.patch \
+	file://kernel-gcc7.patch \
 	${@bb.utils.contains("MACHINE_FEATURES", "dvbproxy", "file://linux_dvb_adapter.patch", "", d)} \
 	file://${MACHINE}_defconfig \
 	"

--- a/recipes-bsp/linux/linux-vuplus-3.14.28.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.14.28.inc
@@ -24,6 +24,7 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KSRC_VER}.tar.b
 	file://0001-stv090x-optimized-TS-sync-control.patch \
 	${@bb.utils.contains("MACHINE_FEATURES", "dvbproxy", "file://linux_dvb_adapter.patch", "", d)} \
 	file://kernel-gcc6.patch \
+	file://kernel-gcc7.patch \
 	file://${MACHINE}_defconfig \
 	"
 

--- a/recipes-bsp/linux/linux-vuplus-3.9.6.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.9.6.inc
@@ -24,6 +24,7 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KV}.tar.bz2 \
 	file://0001-STV-Add-SNR-Signal-report-parameters.patch \
 	file://0001-stv090x-optimized-TS-sync-control.patch \
 	file://kernel-gcc6.patch \
+	file://kernel-gcc7.patch \
 	file://${MACHINE}_defconfig \
 	"
 

--- a/recipes-bsp/linux/linux-vuplus-4.1.20.inc
+++ b/recipes-bsp/linux/linux-vuplus-4.1.20.inc
@@ -17,6 +17,7 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KSRC_VER}.tar.b
 	file://bcmgenet-recovery-fix.patch \
 	${@bb.utils.contains("MACHINE_FEATURES", "dvbproxy", "file://linux_dvb_adapter.patch", "", d)} \
 	file://kernel-gcc6.patch \
+	file://kernel-gcc7.patch \
 	file://${MACHINE}_defconfig \
 	"
 


### PR DESCRIPTION
Add compiler-gcc7.h in kernel tree. This is necessary, to be able to compile the kernel with gcc7, as new OE release rocko comes with gcc7. OpenPLi 7 will use OE rocko.