### PR TITLE
linux_4.1.20.inc: Generalize pkg_postinst_kernel-image script to make…

### DIFF
--- a/recipes-bsp/linux/linux-vuplus-4.1.20.inc
+++ b/recipes-bsp/linux/linux-vuplus-4.1.20.inc
@@ -49,7 +49,7 @@ kernel_do_compile() {
 
 pkg_postinst_kernel-image () {
         if [ -d /proc/stb ] ; then
-                dd if=/${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE} of=/dev/mmcblk0p1
+                dd if=/${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE} of=/dev/${MTD_KERNEL}
         fi
         rm -f /${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}
         true


### PR DESCRIPTION
… it work with all 4k models, vuzero4k included

Use actual partition for kernel as set in config for given machine instead hardcoded one (for vuzero4k it's mmcblk0p4 not p1).