### PR TITLE
machine conf: add streamproxy to EXTRA_IMAGEDEPENDS

### DIFF
--- a/conf/machine/vuduo2.conf
+++ b/conf/machine/vuduo2.conf
@@ -15,7 +15,7 @@ IMAGE_INSTALL_append += "\
 	"
 
 EXTRA_IMAGEDEPENDS += "\
-	enigma2-plugin-systemplugins-transcodingsetup \
+	streamproxy \
 	enigma2-plugin-systemplugins-manualfancontrol \
 "
 

--- a/conf/machine/vusolo2.conf
+++ b/conf/machine/vusolo2.conf
@@ -11,7 +11,7 @@ require conf/machine/include/vuxxo2.inc
 IMAGE_INSTALL_append += "vuplus-initrd-${MACHINE}"
 
 EXTRA_IMAGEDEPENDS += " \
-	enigma2-plugin-systemplugins-transcodingsetup \
+	streamproxy \
 	enigma2-plugin-systemplugins-manualfancontrol \
 "
 

--- a/conf/machine/vusolose.conf
+++ b/conf/machine/vusolose.conf
@@ -12,6 +12,10 @@ IMAGE_INSTALL_append += "\
 	vuplus-initrd-${MACHINE} \
 	"
 
+EXTRA_IMAGEDEPENDS += " \
+	streamproxy \
+"
+
 MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv ctrlrc vupluszap transcoding"
 
 CHIPSET = "bcm7241"

--- a/conf/machine/vuultimo4k.conf
+++ b/conf/machine/vuultimo4k.conf
@@ -16,6 +16,7 @@ IMAGE_INSTALL_append += "\
 	"
 
 EXTRA_IMAGEDEPENDS += " \
+	streamproxy \
 	enigma2-plugin-extensions-webkithbbtv \
 "
 

--- a/conf/machine/vuuno4k.conf
+++ b/conf/machine/vuuno4k.conf
@@ -15,6 +15,7 @@ IMAGE_INSTALL_append += "\
 	"
 
 EXTRA_IMAGEDEPENDS += " \
+	streamproxy \
 	enigma2-plugin-extensions-webkithbbtv \
 "
 

--- a/conf/machine/vuuno4kse.conf
+++ b/conf/machine/vuuno4kse.conf
@@ -15,6 +15,7 @@ IMAGE_INSTALL_append += "\
 	"
 
 EXTRA_IMAGEDEPENDS += " \
+	streamproxy \
 	enigma2-plugin-extensions-webkithbbtv \
 "
 


### PR DESCRIPTION
for machines with 'transcoding' in their MACHINE_FEATURES

Remove enigma2-plugin-systemplugins-transcodingsetup, which is in the
RDEPENDS of the streamproxy.

This commit is required since
https://github.com/OpenPLi/openpli-oe-core/commit/f20ec99ee45799591b3140ed494fb4e16df2f232
in order to get the streamproxy back into the image for vu+ machines