### PR TITLE
streamproxy: use MACHINE_FEATURE.

### DIFF
--- a/conf/machine/vuduo2.conf
+++ b/conf/machine/vuduo2.conf
@@ -12,14 +12,13 @@ IMAGE_INSTALL_append += "\
 	vuplus-initrd-${MACHINE} \
 	enigma2-plugin-extensions-lcd4linux \
 	vuplus-coldboot \
-	"
+"
 
 EXTRA_IMAGEDEPENDS += "\
-	streamproxy \
 	enigma2-plugin-systemplugins-manualfancontrol \
 "
 
-MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv wol ctrlrc transcoding"
+MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv wol ctrlrc transcoding streamproxy"
 
 CHIPSET = "bcm7424"
 

--- a/conf/machine/vusolo2.conf
+++ b/conf/machine/vusolo2.conf
@@ -11,11 +11,10 @@ require conf/machine/include/vuxxo2.inc
 IMAGE_INSTALL_append += "vuplus-initrd-${MACHINE}"
 
 EXTRA_IMAGEDEPENDS += " \
-	streamproxy \
 	enigma2-plugin-systemplugins-manualfancontrol \
 "
 
-MACHINE_FEATURES += "textlcd hbbtv transcoding blindscan-dvbs ctrlrc"
+MACHINE_FEATURES += "textlcd hbbtv transcoding streamproxy blindscan-dvbs ctrlrc"
 
 CHIPSET = "bcm7356"
 

--- a/conf/machine/vusolo4k.conf
+++ b/conf/machine/vusolo4k.conf
@@ -14,12 +14,11 @@ IMAGE_INSTALL_append += "\
 	vuplus-bluetooth-util-${MACHINE} \
 	"
 
-EXTRA_IMAGEDEPENDS += " \
-	streamproxy \
+EXTRA_IMAGEDEPENDS += "\
 	enigma2-plugin-extensions-webkithbbtv \
 "
 
-MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv ctrlrc colorlcd transcoding dvbproxy mmc bluetooth kodi"
+MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv ctrlrc colorlcd transcoding streamproxy dvbproxy mmc bluetooth kodi"
 
 CHIPSET = "bcm7376"
 
@@ -28,4 +27,3 @@ FORCE_REBOOT_OPTION = "reboot"
 MACHINE_KERNEL_PR = "r1"
 
 IMAGE_FSTYPES =+ "ext4"
-

--- a/conf/machine/vusolose.conf
+++ b/conf/machine/vusolose.conf
@@ -10,13 +10,9 @@ require conf/machine/include/vuxxo2.inc
 
 IMAGE_INSTALL_append += "\
 	vuplus-initrd-${MACHINE} \
-	"
-
-EXTRA_IMAGEDEPENDS += " \
-	streamproxy \
 "
 
-MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv ctrlrc vupluszap transcoding"
+MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv ctrlrc vupluszap transcoding streamproxy"
 
 CHIPSET = "bcm7241"
 

--- a/conf/machine/vuultimo4k.conf
+++ b/conf/machine/vuultimo4k.conf
@@ -15,12 +15,11 @@ IMAGE_INSTALL_append += "\
 	vuplus-wifi-util-${MACHINE} \
 	"
 
-EXTRA_IMAGEDEPENDS += " \
-	streamproxy \
+EXTRA_IMAGEDEPENDS += "\
 	enigma2-plugin-extensions-webkithbbtv \
 "
 
-MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv ctrlrc colorlcd transcoding dvbproxy mmc bluetooth bcmwifi kodi"
+MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv ctrlrc colorlcd transcoding streamproxy dvbproxy mmc bluetooth bcmwifi kodi"
 
 CHIPSET = "bcm7444"
 
@@ -29,4 +28,3 @@ FORCE_REBOOT_OPTION = "reboot"
 MACHINE_KERNEL_PR = "r1"
 
 IMAGE_FSTYPES =+ "ext4"
-

--- a/conf/machine/vuuno4k.conf
+++ b/conf/machine/vuuno4k.conf
@@ -14,12 +14,11 @@ IMAGE_INSTALL_append += "\
 	vuplus-bluetooth-util-${MACHINE} \
 	"
 
-EXTRA_IMAGEDEPENDS += " \
-	streamproxy \
+EXTRA_IMAGEDEPENDS += "\
 	enigma2-plugin-extensions-webkithbbtv \
 "
 
-MACHINE_FEATURES += "dvb-c blindscan-dvbc hbbtv ctrlrc transcoding dvbproxy mmc bluetooth kodi"
+MACHINE_FEATURES += "dvb-c blindscan-dvbc hbbtv ctrlrc transcoding streamproxy dvbproxy mmc bluetooth kodi"
 
 CHIPSET = "bcm7252S"
 
@@ -28,4 +27,3 @@ FORCE_REBOOT_OPTION = "force"
 MACHINE_KERNEL_PR = "r1"
 
 IMAGE_FSTYPES =+ "ext4"
-

--- a/conf/machine/vuuno4kse.conf
+++ b/conf/machine/vuuno4kse.conf
@@ -12,14 +12,13 @@ IMAGE_INSTALL_append += "\
 	vuplus-initrd-${MACHINE} \
 	enigma2-plugin-systemplugins-bluetoothsetup \
 	vuplus-bluetooth-util-${MACHINE} \
-	"
+"
 
-EXTRA_IMAGEDEPENDS += " \
-	streamproxy \
+EXTRA_IMAGEDEPENDS += "\
 	enigma2-plugin-extensions-webkithbbtv \
 "
 
-MACHINE_FEATURES += "dvb-c blindscan-dvbc hbbtv ctrlrc colorlcd transcoding dvbproxy mmc bluetooth kodi"
+MACHINE_FEATURES += "dvb-c blindscan-dvbc hbbtv ctrlrc colorlcd transcoding streamproxy dvbproxy mmc bluetooth kodi"
 
 CHIPSET = "bcm7252S"
 


### PR DESCRIPTION
As it's now, streamproxy is included in the feed but not in the image. This is confusing for users.

meta-openpli now has had an change to handle this and makes streamproxy include into the image when the streamproxy MACHINE_FEATURE is set.