### PR TITLE
PR's for OE Sumo compatibility

### DIFF
--- a/recipes-bsp/drivers/vuplus-dvb-proxy.inc
+++ b/recipes-bsp/drivers/vuplus-dvb-proxy.inc
@@ -13,7 +13,7 @@ S = "${WORKDIR}"
 #inherit module-base
 DEPENDS = "virtual/kernel"
 do_configure[depends] += "virtual/kernel:do_shared_workdir"
-KERNEL_VERSION = "${@base_read_file('${STAGING_KERNEL_BUILDDIR}/kernel-abiversion')}"
+KERNEL_VERSION = "${@oe.utils.read_file('${STAGING_KERNEL_BUILDDIR}/kernel-abiversion')}"
 
 do_install() {
         install -d ${D}/lib/modules/${KERNEL_VERSION}/extra

--- a/recipes-bsp/linux/files/0002-mips-kernel-fpu-gcc7.patch
+++ b/recipes-bsp/linux/files/0002-mips-kernel-fpu-gcc7.patch
@@ -1,0 +1,53 @@
+From: Manuel Lauss <manuel.lauss at gmail.com>
+
+commit 8535f2ba0a9b971df62a5890699b9dfe2e0d5580 upstream
+
+MIPS: math-emu: do not use bools for arithmetic
+
+GCC-7 complains about a boolean value being used with an arithmetic
+AND:
+
+arch/mips/math-emu/cp1emu.c: In function 'cop1Emulate':
+arch/mips/math-emu/cp1emu.c:838:14: warning: '~' on a boolean expression [-Wbool-operation]
+  fpr = (x) & ~(cop1_64bit(xcp) == 0);    \
+                ^
+arch/mips/math-emu/cp1emu.c:1068:3: note: in expansion of macro 'DITOREG'
+  DITOREG(dval, MIPSInst_RT(ir));
+  ^~~~~~~
+arch/mips/math-emu/cp1emu.c:838:14: note: did you mean to use logical not?
+  fpr = (x) & ~(cop1_64bit(xcp) == 0);    \
+
+Since cop1_64bit() returns and int, just flip the LSB.
+
+Updated-by: Erik slagter <erik@openpli.org>
+Suggested-by: Maciej W. Rozycki <macro at imgtec.com>
+Signed-off-by: Manuel Lauss <manuel.lauss at gmail.com>
+Reviewed-by: Maciej W. Rozycki <macro at imgtec.com>
+Cc: linux-mips at linux-mips.org
+Patchwork: https://patchwork.linux-mips.org/patch/17058/
+Signed-off-by: Ralf Baechle <ralf at linux-mips.org>
+Signed-off-by: Hongzhi Song <hongzhi.song at windriver.com>
+---
+arch/mips/math-emu/cp1emu.c | 4 ++--
+1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff -ur a/arch/mips/math-emu/cp1emu.c b/arch/mips/math-emu/cp1emu.c
+--- kernel-source-unpatched/arch/mips/math-emu/cp1emu.c	2014-03-12 09:27:05.000000000 +0100
++++ kernel-source-patched/arch/mips/math-emu/cp1emu.c	2018-10-11 19:56:35.532651188 +0200
+@@ -191,13 +191,13 @@
+ #define SIFROMREG(si, x) ((si) = cop1_64bit(xcp) || !(x & 1) ? \
+ 			(int)ctx->fpr[x] : (int)(ctx->fpr[x & ~1] >> 32))
+ 
+-#define SITOREG(si, x)	(ctx->fpr[x & ~(cop1_64bit(xcp) == 0)] = \
++#define SITOREG(si, x)	(ctx->fpr[x & ~(cop1_64bit(xcp) ^ 1)] = \
+ 			cop1_64bit(xcp) || !(x & 1) ? \
+ 			ctx->fpr[x & ~1] >> 32 << 32 | (u32)(si) : \
+ 			ctx->fpr[x & ~1] << 32 >> 32 | (u64)(si) << 32)
+ 
+-#define DIFROMREG(di, x) ((di) = ctx->fpr[x & ~(cop1_64bit(xcp) == 0)])
+-#define DITOREG(di, x)	(ctx->fpr[x & ~(cop1_64bit(xcp) == 0)] = (di))
++#define DIFROMREG(di, x) ((di) = ctx->fpr[x & ~(cop1_64bit(xcp) ^ 1)])
++#define DITOREG(di, x)	(ctx->fpr[x & ~(cop1_64bit(xcp) ^ 1)] = (di))
+ 
+ #define SPFROMREG(sp, x) SIFROMREG((sp).bits, x)
+ #define SPTOREG(sp, x)	SITOREG((sp).bits, x)

--- a/recipes-bsp/linux/files/0003-mips-kernel-ilog2-gcc7.patch
+++ b/recipes-bsp/linux/files/0003-mips-kernel-ilog2-gcc7.patch
@@ -1,0 +1,38 @@
+diff --git a/include/linux/log2.h b/include/linux/log2.h
+index ef3d4f67118c..c373295f359f 100644
+--- a/include/linux/log2.h
++++ b/include/linux/log2.h
+@@ -16,12 +16,6 @@
+ #include <linux/bitops.h>
+ 
+ /*
+- * deal with unrepresentable constant logarithms
+- */
+-extern __attribute__((const, noreturn))
+-int ____ilog2_NaN(void);
+-
+-/*
+  * non-constant log of base 2 calculators
+  * - the arch may override these in asm/bitops.h if they can be implemented
+  *   more efficiently than using fls() and fls64()
+@@ -85,7 +79,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ #define ilog2(n)				\
+ (						\
+ 	__builtin_constant_p(n) ? (		\
+-		(n) < 1 ? ____ilog2_NaN() :	\
++		(n) < 2 ? 0 :			\
+ 		(n) & (1ULL << 63) ? 63 :	\
+ 		(n) & (1ULL << 62) ? 62 :	\
+ 		(n) & (1ULL << 61) ? 61 :	\
+@@ -148,10 +142,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ 		(n) & (1ULL <<  4) ?  4 :	\
+ 		(n) & (1ULL <<  3) ?  3 :	\
+ 		(n) & (1ULL <<  2) ?  2 :	\
+-		(n) & (1ULL <<  1) ?  1 :	\
+-		(n) & (1ULL <<  0) ?  0 :	\
+-		____ilog2_NaN()			\
+-				   ) :		\
++		1 ) :				\
+ 	(sizeof(n) <= 4) ?			\
+ 	__ilog2_u32(n) :			\
+ 	__ilog2_u64(n)				\

--- a/recipes-bsp/linux/linux-vuplus-3.13.5.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.13.5.inc
@@ -22,6 +22,7 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KV}.tar.bz2 \
 	file://0001-STV-Add-PLS-support.patch \
 	file://0001-STV-Add-SNR-Signal-report-parameters.patch \
 	file://0001-stv090x-optimized-TS-sync-control.patch \
+	file://0002-mips-kernel-fpu-gcc7.patch \
 	file://kernel-gcc6.patch \
 	file://kernel-gcc7.patch \
 	${@bb.utils.contains("MACHINE_FEATURES", "dvbproxy", "file://linux_dvb_adapter.patch", "", d)} \

--- a/recipes-bsp/linux/linux-vuplus-3.13.5.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.13.5.inc
@@ -23,6 +23,7 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KV}.tar.bz2 \
 	file://0001-STV-Add-SNR-Signal-report-parameters.patch \
 	file://0001-stv090x-optimized-TS-sync-control.patch \
 	file://0002-mips-kernel-fpu-gcc7.patch \
+	file://0003-mips-kernel-ilog2-gcc7.patch \
 	file://kernel-gcc6.patch \
 	file://kernel-gcc7.patch \
 	${@bb.utils.contains("MACHINE_FEATURES", "dvbproxy", "file://linux_dvb_adapter.patch", "", d)} \

--- a/recipes-bsp/linux/linux-vuplus-3.9.6.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.9.6.inc
@@ -23,6 +23,7 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KV}.tar.bz2 \
 	file://0001-STV-Add-PLS-support.patch \
 	file://0001-STV-Add-SNR-Signal-report-parameters.patch \
 	file://0001-stv090x-optimized-TS-sync-control.patch \
+	file://0002-mips-kernel-fpu-gcc7.patch \
 	file://kernel-gcc6.patch \
 	file://kernel-gcc7.patch \
 	file://${MACHINE}_defconfig \

--- a/recipes-bsp/linux/linux-vuplus-3.9.6.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.9.6.inc
@@ -24,6 +24,7 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KV}.tar.bz2 \
 	file://0001-STV-Add-SNR-Signal-report-parameters.patch \
 	file://0001-stv090x-optimized-TS-sync-control.patch \
 	file://0002-mips-kernel-fpu-gcc7.patch \
+	file://0003-mips-kernel-ilog2-gcc7.patch \
 	file://kernel-gcc6.patch \
 	file://kernel-gcc7.patch \
 	file://${MACHINE}_defconfig \

--- a/recipes-webkit/webkit/webkit-gtk_git.bb
+++ b/recipes-webkit/webkit/webkit-gtk_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "\
 	file://Source/JavaScriptCore/parser/Parser.h;endline=23;md5=2f3cff0ad0a9c486da5a376928973a90 \
 	"
 
-DEPENDS = "glib-2.0 icu zlib enchant libsoup-2.4 curl libxml2 cairo libidn gnutls \
+DEPENDS = "glib-2.0 glib-2.0-native gettext-native zlib enchant libsoup-2.4 curl libxml2 cairo libidn gnutls \
            gtk+ gstreamer1.0 gstreamer1.0-plugins-base flex-native bison-native gperf-native sqlite3 \
            libxslt zlib libpcre harfbuzz pango atk udev"
 

--- a/recipes-webkit/webkit/webkit-gtk_git.bb
+++ b/recipes-webkit/webkit/webkit-gtk_git.bb
@@ -61,6 +61,8 @@ LDFLAGS += "-Wl,--no-keep-memory"
 
 CXXFLAGS += " -std=gnu++98"
 
+OECMAKE_GENERATOR = "Unix Makefiles"
+
 EXTRA_AUTORECONF = " -I Source/autotools "
 
 ARM_INSTRUCTION_SET = "arm"


### PR DESCRIPTION
Please apply.

These commits do not fix Linux kernel 3.9.6 and 3.13.5 generation (/tmp/vmlinux.gz is not found/installed in the kernel package), I don't know how to fix it unfortunately.

Thanks,
Erik.