### PR TITLE
Fix warnings about replacing original key "FILES_kernel-image"

### DIFF
--- a/recipes-bsp/linux/linux-vuplus-3.13.5.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.13.5.inc
@@ -41,8 +41,7 @@ KERNEL_OUTPUT_DIR = "."
 KERNEL_OBJECT_SUFFIX = "ko"
 KERNEL_IMAGEDEST = "/tmp"
 
-KERNEL_PACKAGE_NAME ??= "kernel"
-FILES_${KERNEL_PACKAGE_NAME}-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz"
+FILES_kernel-image = "/${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz"
 
 do_configure_prepend() {
 	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig

--- a/recipes-bsp/linux/linux-vuplus-3.14.28.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.14.28.inc
@@ -38,8 +38,7 @@ KERNEL_OUTPUT = "arch/${ARCH}/boot/${KERNEL_IMAGETYPE}"
 KERNEL_OBJECT_SUFFIX = "ko"
 KERNEL_IMAGEDEST = "tmp"
 
-KERNEL_PACKAGE_NAME ??= "kernel"
-FILES_${KERNEL_PACKAGE_NAME}-image = "/${KERNEL_IMAGEDEST}/zImage"
+FILES_kernel-image = "/${KERNEL_IMAGEDEST}/zImage"
 
 do_configure_prepend() {
 	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig

--- a/recipes-bsp/linux/linux-vuplus-3.9.6.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.9.6.inc
@@ -41,8 +41,7 @@ KERNEL_OUTPUT_DIR = "."
 KERNEL_OBJECT_SUFFIX = "ko"
 KERNEL_IMAGEDEST = "/tmp"
 
-KERNEL_PACKAGE_NAME ??= "kernel"
-FILES_${KERNEL_PACKAGE_NAME}-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz"
+FILES_kernel-image = "/${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz"
 
 do_configure_prepend() {
 	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig

--- a/recipes-bsp/linux/linux-vuplus-4.1.20.inc
+++ b/recipes-bsp/linux/linux-vuplus-4.1.20.inc
@@ -31,8 +31,7 @@ KERNEL_OUTPUT = "arch/${ARCH}/boot/${KERNEL_IMAGETYPE}"
 KERNEL_OBJECT_SUFFIX = "ko"
 KERNEL_IMAGEDEST = "tmp"
 
-KERNEL_PACKAGE_NAME ??= "kernel"
-FILES_${KERNEL_PACKAGE_NAME}-image = "/${KERNEL_IMAGEDEST}/zImage"
+FILES_kernel-image = "/${KERNEL_IMAGEDEST}/zImage"
 
 do_configure_prepend() {
 	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig

--- a/recipes-bsp/linux/linux-vuplus-4.1.45.inc
+++ b/recipes-bsp/linux/linux-vuplus-4.1.45.inc
@@ -30,8 +30,7 @@ KERNEL_OUTPUT = "arch/${ARCH}/boot/${KERNEL_IMAGETYPE}"
 KERNEL_OBJECT_SUFFIX = "ko"
 KERNEL_IMAGEDEST = "tmp"
 
-KERNEL_PACKAGE_NAME ??= "kernel"
-FILES_${KERNEL_PACKAGE_NAME}-image = "/${KERNEL_IMAGEDEST}/zImage"
+FILES_kernel-image = "/${KERNEL_IMAGEDEST}/zImage"
 
 do_configure_prepend() {
 	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig


### PR DESCRIPTION
Fix warnings about replacing original key "FILES_kernel-image"
* Update linux-vuplus-4.1.45.inc
* Update linux-vuplus-4.1.20.inc
* Update linux-vuplus-3.9.6.inc
* Update linux-vuplus-3.14.28.inc
* Update linux-vuplus-3.13.5.inc