### PR TITLE
OE: prevent python executable from host being used, use OE's native one instead.

### DIFF
--- a/recipes-bsp/drivers/bluetoothsetup.inc
+++ b/recipes-bsp/drivers/bluetoothsetup.inc
@@ -1,5 +1,7 @@
 DESCRIPTION = "Vuplus bluetooth plugin"
 
+inherit pythonnative
+
 LICENSE = "CLOSED"
 
 DEPENDS = "python-native"

--- a/recipes-bsp/drivers/vuplus-enigma2-packages.bb
+++ b/recipes-bsp/drivers/vuplus-enigma2-packages.bb
@@ -8,7 +8,7 @@ DEPENDS = "python-native"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 SRCREV = "b0fb2521cedeac8089de73c3b59fd15bda0e99e0"
-inherit gitpkgv
+inherit gitpkgv pythonnative
  
 PV = "experimental-git${SRCPV}"
 PKGV = "experimental-git${GITPKGV}"

--- a/recipes-bsp/linux/files/0002-log2-give-up-on-gcc-constant-optimizations.patch
+++ b/recipes-bsp/linux/files/0002-log2-give-up-on-gcc-constant-optimizations.patch
@@ -1,0 +1,85 @@
+From 05a1328f10d503e2b3156226cef36b0d0c4df7b2 Mon Sep 17 00:00:00 2001
+From: Nicker <nickersk@gmail.com>
+Date: Mon, 23 Jul 2018 14:53:12 +0200
+Subject: [PATCH 2/2] log2 give up on gcc constant optimizations
+
+
+diff --git a/include/linux/log2.h b/include/linux/log2.h
+index fd7ff3d9..f38fae23 100644
+--- a/include/linux/log2.h
++++ b/include/linux/log2.h
+@@ -15,12 +15,6 @@
+ #include <linux/types.h>
+ #include <linux/bitops.h>
+ 
+-/*
+- * deal with unrepresentable constant logarithms
+- */
+-extern __attribute__((const, noreturn))
+-int ____ilog2_NaN(void);
+-
+ /*
+  * non-constant log of base 2 calculators
+  * - the arch may override these in asm/bitops.h if they can be implemented
+@@ -85,7 +79,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ #define ilog2(n)				\
+ (						\
+ 	__builtin_constant_p(n) ? (		\
+-		(n) < 1 ? ____ilog2_NaN() :	\
++		(n) < 2 ? 0 :			\
+ 		(n) & (1ULL << 63) ? 63 :	\
+ 		(n) & (1ULL << 62) ? 62 :	\
+ 		(n) & (1ULL << 61) ? 61 :	\
+@@ -148,10 +142,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ 		(n) & (1ULL <<  4) ?  4 :	\
+ 		(n) & (1ULL <<  3) ?  3 :	\
+ 		(n) & (1ULL <<  2) ?  2 :	\
+-		(n) & (1ULL <<  1) ?  1 :	\
+-		(n) & (1ULL <<  0) ?  0 :	\
+-		____ilog2_NaN()			\
+-				   ) :		\
++		1 ) :				\
+ 	(sizeof(n) <= 4) ?			\
+ 	__ilog2_u32(n) :			\
+ 	__ilog2_u64(n)				\
+diff --git a/tools/include/linux/log2.h b/tools/include/linux/log2.h
+index 41446668..d5677d39 100644
+--- a/tools/include/linux/log2.h
++++ b/tools/include/linux/log2.h
+@@ -12,12 +12,6 @@
+ #ifndef _TOOLS_LINUX_LOG2_H
+ #define _TOOLS_LINUX_LOG2_H
+ 
+-/*
+- * deal with unrepresentable constant logarithms
+- */
+-extern __attribute__((const, noreturn))
+-int ____ilog2_NaN(void);
+-
+ /*
+  * non-constant log of base 2 calculators
+  * - the arch may override these in asm/bitops.h if they can be implemented
+@@ -78,7 +72,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ #define ilog2(n)				\
+ (						\
+ 	__builtin_constant_p(n) ? (		\
+-		(n) < 1 ? ____ilog2_NaN() :	\
++		(n) < 2 ? 0 :			\
+ 		(n) & (1ULL << 63) ? 63 :	\
+ 		(n) & (1ULL << 62) ? 62 :	\
+ 		(n) & (1ULL << 61) ? 61 :	\
+@@ -141,10 +135,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ 		(n) & (1ULL <<  4) ?  4 :	\
+ 		(n) & (1ULL <<  3) ?  3 :	\
+ 		(n) & (1ULL <<  2) ?  2 :	\
+-		(n) & (1ULL <<  1) ?  1 :	\
+-		(n) & (1ULL <<  0) ?  0 :	\
+-		____ilog2_NaN()			\
+-				   ) :		\
++		1 ) :				\
+ 	(sizeof(n) <= 4) ?			\
+ 	__ilog2_u32(n) :			\
+ 	__ilog2_u64(n)				\
+-- 
+2.17.1
+

--- a/recipes-bsp/linux/files/0003-3.x-uaccess-dont-mark-register-as-const.patch
+++ b/recipes-bsp/linux/files/0003-3.x-uaccess-dont-mark-register-as-const.patch
@@ -1,0 +1,22 @@
+From 0315d0e395c153fe8c67d1dcdd4544ad85af01c4 Mon Sep 17 00:00:00 2001
+From: Nicker <nickersk@gmail.com>
+Date: Sun, 5 Aug 2018 20:56:08 +0200
+Subject: [PATCH] uaccess dont mark register as const
+
+
+diff --git a/arch/arm/include/asm/uaccess.h b/arch/arm/include/asm/uaccess.h
+index 7f3f3cc2..e6218568 100644
+--- a/arch/arm/include/asm/uaccess.h
++++ b/arch/arm/include/asm/uaccess.h
+@@ -172,7 +172,7 @@ extern int __put_user_8(void *, unsigned long long);
+ 	({								\
+ 		unsigned long __limit = current_thread_info()->addr_limit - 1; \
+ 		const typeof(*(p)) __user *__tmp_p = (p);		\
+-		register const typeof(*(p)) __r2 asm("r2") = (x);	\
++		register typeof(*(p)) __r2 asm("r2") = (x);	\
+ 		register const typeof(*(p)) __user *__p asm("r0") = __tmp_p; \
+ 		register unsigned long __l asm("r1") = __limit;		\
+ 		register int __e asm("r0");				\
+-- 
+2.17.1
+

--- a/recipes-bsp/linux/files/0003-dont-mark-register-as-const.patch
+++ b/recipes-bsp/linux/files/0003-dont-mark-register-as-const.patch
@@ -1,0 +1,22 @@
+From 94991ba321b4b112656998e586b46107afaa50d6 Mon Sep 17 00:00:00 2001
+From: Nicker <nickersk@gmail.com>
+Date: Mon, 23 Jul 2018 15:25:12 +0200
+Subject: [PATCH 3/3] dont mark register as const
+
+
+diff --git a/arch/arm/include/asm/uaccess.h b/arch/arm/include/asm/uaccess.h
+index 7fb59199..7665bd2f 100644
+--- a/arch/arm/include/asm/uaccess.h
++++ b/arch/arm/include/asm/uaccess.h
+@@ -251,7 +251,7 @@ extern int __put_user_8(void *, unsigned long long);
+ 	({								\
+ 		unsigned long __limit = current_thread_info()->addr_limit - 1; \
+ 		const typeof(*(p)) __user *__tmp_p = (p);		\
+-		register const typeof(*(p)) __r2 asm("r2") = (x);	\
++		register typeof(*(p)) __r2 asm("r2") = (x);	\
+ 		register const typeof(*(p)) __user *__p asm("r0") = __tmp_p; \
+ 		register unsigned long __l asm("r1") = __limit;		\
+ 		register int __e asm("r0");				\
+-- 
+2.17.1
+

--- a/recipes-bsp/linux/files/kernel-gcc8.patch
+++ b/recipes-bsp/linux/files/kernel-gcc8.patch
@@ -1,0 +1,67 @@
+diff --git a/include/linux/compiler-gcc8.h b/include/linux/compiler-gcc8.h
+new file mode 100644
+index 0000000..ba064fa
+--- /dev/null
++++ b/include/linux/compiler-gcc8.h
+@@ -0,0 +1,59 @@
++#ifndef __LINUX_COMPILER_H
++#error "Please don't include <linux/compiler-gcc8.h> directly, include <linux/compiler.h> instead."
++#endif
++
++#define __used				__attribute__((__used__))
++#define __must_check			__attribute__((warn_unused_result))
++#define __compiler_offsetof(a, b)	__builtin_offsetof(a, b)
++
++/* Mark functions as cold. gcc will assume any path leading to a call
++   to them will be unlikely.  This means a lot of manual unlikely()s
++   are unnecessary now for any paths leading to the usual suspects
++   like BUG(), printk(), panic() etc. [but let's keep them for now for
++   older compilers]
++
++   gcc also has a __attribute__((__hot__)) to move hot functions into
++   a special section, but I don't see any sense in this right now in
++   the kernel context */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible __attribute__((externally_visible))
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#define __HAVE_BUILTIN_BSWAP16__
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
++
++#define KASAN_ABI_VERSION 4
+-- 
+2.1.0

--- a/recipes-bsp/linux/linux-vuplus-3.13.5.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.13.5.inc
@@ -40,20 +40,21 @@ KERNEL_IMAGETYPE = "vmlinux"
 KERNEL_OUTPUT = "vmlinux"
 KERNEL_OUTPUT_DIR = "."
 KERNEL_OBJECT_SUFFIX = "ko"
-KERNEL_IMAGEDEST = "/tmp"
+KERNEL_IMAGEDEST = "tmp"
 
 KERNEL_EXTRA_ARGS = "EXTRA_CFLAGS=-Wno-attribute-alias"
+KERNEL_PACKAGE_NAME = "kernel"
 
-FILES_kernel-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz"
+FILES_${KERNEL_PACKAGE_NAME}-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz"
 
 do_configure_prepend() {
 	oe_machinstall -m 0644 ${WORKDIR}/${MACHINE}_defconfig ${WORKDIR}/defconfig
 }
 
 kernel_do_install_append() {
-	install -d ${D}/${KERNEL_IMAGEDEST}
-	install -m 0755 ${KERNEL_OUTPUT} ${D}${KERNEL_IMAGEDEST}
-	gzip ${D}${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}
+	${STRIP} ${D}/${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}-${KERNEL_VERSION}
+	gzip -9c ${D}/${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}-${KERNEL_VERSION} > ${D}/${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz
+	rm ${D}/${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}-${KERNEL_VERSION}
 }
 
 pkg_postinst_kernel-image () {
@@ -64,3 +65,6 @@ pkg_postinst_kernel-image () {
 	rm -f /${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz
 	true
 }
+
+# extra tasks
+addtask kernel_link_images after do_compile before do_install

--- a/recipes-bsp/linux/linux-vuplus-3.13.5.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.13.5.inc
@@ -26,6 +26,7 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KV}.tar.bz2 \
 	file://0003-mips-kernel-ilog2-gcc7.patch \
 	file://kernel-gcc6.patch \
 	file://kernel-gcc7.patch \
+	file://kernel-gcc8.patch \
 	${@bb.utils.contains("MACHINE_FEATURES", "dvbproxy", "file://linux_dvb_adapter.patch", "", d)} \
 	file://${MACHINE}_defconfig \
 	"
@@ -40,6 +41,8 @@ KERNEL_OUTPUT = "vmlinux"
 KERNEL_OUTPUT_DIR = "."
 KERNEL_OBJECT_SUFFIX = "ko"
 KERNEL_IMAGEDEST = "/tmp"
+
+KERNEL_EXTRA_ARGS = "EXTRA_CFLAGS=-Wno-attribute-alias"
 
 FILES_kernel-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}.gz"
 

--- a/recipes-bsp/linux/linux-vuplus-3.14.28.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.14.28.inc
@@ -25,6 +25,9 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KSRC_VER}.tar.b
 	${@bb.utils.contains("MACHINE_FEATURES", "dvbproxy", "file://linux_dvb_adapter.patch", "", d)} \
 	file://kernel-gcc6.patch \
 	file://kernel-gcc7.patch \
+	file://kernel-gcc8.patch \
+	file://0003-mips-kernel-ilog2-gcc7.patch \
+	file://0003-3.x-uaccess-dont-mark-register-as-const.patch \
 	file://${MACHINE}_defconfig \
 	"
 

--- a/recipes-bsp/linux/linux-vuplus-3.9.6.inc
+++ b/recipes-bsp/linux/linux-vuplus-3.9.6.inc
@@ -27,6 +27,7 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KV}.tar.bz2 \
 	file://0003-mips-kernel-ilog2-gcc7.patch \
 	file://kernel-gcc6.patch \
 	file://kernel-gcc7.patch \
+	file://kernel-gcc8.patch \
 	file://${MACHINE}_defconfig \
 	"
 

--- a/recipes-bsp/linux/linux-vuplus-4.1.20.inc
+++ b/recipes-bsp/linux/linux-vuplus-4.1.20.inc
@@ -18,6 +18,9 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KSRC_VER}.tar.b
 	${@bb.utils.contains("MACHINE_FEATURES", "dvbproxy", "file://linux_dvb_adapter.patch", "", d)} \
 	file://kernel-gcc6.patch \
 	file://kernel-gcc7.patch \
+	file://kernel-gcc8.patch \
+	file://0002-log2-give-up-on-gcc-constant-optimizations.patch \
+	file://0003-dont-mark-register-as-const.patch \
 	file://${MACHINE}_defconfig \
 	"
 

--- a/recipes-bsp/linux/linux-vuplus-4.1.45.inc
+++ b/recipes-bsp/linux/linux-vuplus-4.1.45.inc
@@ -17,6 +17,8 @@ SRC_URI += "http://archive.vuplus.com/download/kernel/stblinux-${KSRC_VER}.tar.b
 	${@bb.utils.contains("MACHINE_FEATURES", "dvbproxy", "file://linux_dvb_adapter.patch", "", d)} \
 	file://kernel-gcc6.patch \
 	file://kernel-gcc7.patch \
+	file://0002-log2-give-up-on-gcc-constant-optimizations.patch \
+	file://0003-dont-mark-register-as-const.patch \
 	file://${MACHINE}_defconfig \
 	"
 


### PR DESCRIPTION
OE: prevent python executable from host being used, use OE's native one instead. This will fix Python "obsoletion" errors when a recent Linux distribution is used to build OE and images.