### PR TITLE
OE: prevent python executable from host being used, use OE's native o…

### DIFF
--- a/recipes-bsp/drivers/bluetoothsetup.inc
+++ b/recipes-bsp/drivers/bluetoothsetup.inc
@@ -1,5 +1,7 @@
 DESCRIPTION = "Vuplus bluetooth plugin"
 
+inherit pythonnative
+
 LICENSE = "CLOSED"
 
 DEPENDS = "python-native"

--- a/recipes-bsp/drivers/vuplus-enigma2-packages.bb
+++ b/recipes-bsp/drivers/vuplus-enigma2-packages.bb
@@ -8,7 +8,7 @@ DEPENDS = "python-native"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 SRCREV = "b0fb2521cedeac8089de73c3b59fd15bda0e99e0"
-inherit gitpkgv
+inherit gitpkgv pythonnative
  
 PV = "experimental-git${SRCPV}"
 PKGV = "experimental-git${GITPKGV}"


### PR DESCRIPTION
OE: prevent python executable from host being used, use OE's native one instead. This will fix Python "obsoletion" errors when a recent Linux distribution is used to build OE and images.