### PR TITLE
libgles-vuxxo2: update EGL/OpenGL headers

### DIFF
--- a/recipes-bsp/drivers/libgles.inc
+++ b/recipes-bsp/drivers/libgles.inc
@@ -7,9 +7,29 @@ COMPATIBLE_MACHINE = "vu"
 PV="15.1"
 PR="${SRCDATE}.${SRCDATE_PR}"
 
+S = "${WORKDIR}/libgles-${MACHINE}"
+
+# Closed source
 SRC_URI = "http://archive.vuplus.com/download/build_support/vuplus/libgles-${MACHINE}-${PV}-${PR}.tar.gz"
 
-S = "${WORKDIR}/libgles-${MACHINE}"
+SRC_URI += "git://github.com/KhronosGroup/EGL-Registry;name=eglh;subpath=api;destsuffix=${S}/egl"
+SRCREV_eglh = "90b78b0662e2f0548cfd1926fb77bf628933541b"
+
+SRC_URI += "git://github.com/KhronosGroup/OpenGL-Registry;name=openglh;subpath=api;destsuffix=${S}/opengl"
+SRCREV_openglh = "8261133c2645aaeef880c5f5a6e327f399bc9d04"
+
+# BEGL patch for eglplatform.h
+SRC_URI_append_vuduo2 = " file://vuxxo2-BEGL.patch"
+SRC_URI_append_vusolo2 = " file://vuxxo2-BEGL.patch"
+SRC_URI_append_vusolose = " file://vuxxo2-BEGL.patch"
+
+do_install_prepend() {
+	cp -a ${S}/egl/EGL/* ${S}/include/EGL/
+	cp -a ${S}/egl/KHR/* ${S}/include/KHR/
+
+	cp -a ${S}/opengl/GLES/*.h ${S}/include/GLES/
+	cp -a ${S}/opengl/GLES2/* ${S}/include/GLES2/
+}
 
 do_install() {
 	install -d ${D}${libdir}
@@ -30,3 +50,5 @@ FILES_${PN}="${libdir}"
 RPROVIDES_${PN} = "libEGL.so libGLESv2.so libdvb_base.so libdvb_client.so libnxpl.so libv3ddriver.so"
 
 INSANE_SKIP_${PN} = "already-stripped"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/vuplus-libgles:"

--- a/recipes-bsp/drivers/vuplus-libgles/vuxxo2-BEGL.patch
+++ b/recipes-bsp/drivers/vuplus-libgles/vuxxo2-BEGL.patch
@@ -1,0 +1,56 @@
+diff --git a/eglplatform.h b/eglplatform.h
+index eaac469..a7bf9fe 100644
+--- a/egl/EGL/eglplatform.h
++++ b/egl/EGL/eglplatform.h
+@@ -36,6 +36,10 @@
+ 
+ #include <KHR/khrplatform.h>
+ 
++#include "begl_memplatform.h"
++#include "begl_hwplatform.h"
++#include "begl_dispplatform.h"
++
+ /* Macros used in EGL function prototype declarations.
+  *
+  * EGL functions should be prototyped as:
+@@ -179,4 +183,40 @@ typedef khronos_int32_t EGLint;
+ #define EGL_CAST(type, value) ((type) (value))
+ #endif
+ 
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/*
++The client application, or default platform library must register valid versions of each of these 
++interfaces before any EGL or GL functions are invoked, using the following functions provided by the 3D driver.
++*/
++typedef struct
++{
++   BEGL_MemoryInterface  *memInterface;      /* Memory interface which will called by the 3d driver   */
++   BEGL_HWInterface      *hwInterface;       /* Hardware interface which will be called by the driver */
++   BEGL_DisplayInterface *displayInterface;  /* Display interface which will be called by the driver  */
++
++   BEGL_DisplayCallbacks  displayCallbacks;  /* Callback pointers set by BEGL_GetDefaultDriverInterfaces, for client to call into driver */
++   BEGL_HardwareCallbacks hardwareCallbacks; /* Callback pointers set by BEGL_GetDefaultDriverInterfaces, for client to call into driver */
++
++   int hwInterfaceCloned;
++   int memInterfaceCloned;
++   void *memInterfaceFn;
++   void *hwInterfaceFn;
++} BEGL_DriverInterfaces;
++
++/* Register application level overrides for any or all of the abstract API calls made by the 3D driver. */
++EGLAPI void EGLAPIENTRY BEGL_RegisterDriverInterfaces(BEGL_DriverInterfaces *iface);
++
++/* Get a pointer to the registered driver interfaces, can be used to override partial defaults - see android platform layer(s) for example */
++EGLAPI BEGL_DriverInterfaces * BEGL_GetDriverInterfaces(void);
++
++/* Initializes all interfaces in the structure to NULL, fills out Callbacks with appropriate function pointers */
++EGLAPI void EGLAPIENTRY BEGL_GetDefaultDriverInterfaces(BEGL_DriverInterfaces *iface);
++
++#ifdef __cplusplus
++}
++#endif
++
+ #endif /* __eglplatform_h */


### PR DESCRIPTION
For mipsel STB nowadays some sources do require modern headers to build.

For example,these are the first missing definitions for kodi_18:
EGL_DEBUG_MSG_CRITICAL_KHR,
EGL_DEBUG_MSG_ERROR_KHR,
EGL_DEBUG_MSG_WARN_KHR,
EGL_DEBUG_MSG_INFO_KHR,
...

We apply the minimal diff (BEGL patch) to the upstream sources
for future upgrades.

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>