### PR TITLE
bsp: update machine features

### DIFF
--- a/conf/machine/include/vuxxo.inc
+++ b/conf/machine/include/vuxxo.inc
@@ -60,6 +60,6 @@ IMAGE_CMD_ubi_append = " \
 	rm -rf vuplus; \
 "
 
-MACHINE_FEATURES += "alsa usbhost wlan kernelwifi externalwifi 3dtv switchoff osdposition hdmicec"
+MACHINE_FEATURES += "alsa usbhost wlan 3dtv switchoff osdposition hdmicec"
 
 require conf/machine/include/tune-mips32.inc

--- a/conf/machine/include/vuxxo2.inc
+++ b/conf/machine/include/vuxxo2.inc
@@ -70,7 +70,7 @@ IMAGE_CMD_ubi_append = " \
 	rm -rf vuplus; \
 "
 
-MACHINE_FEATURES += "alsa usbhost wlan kernelwifi extrakernelwifi 3dtv switchoff osdposition hdmicec fan"
+MACHINE_FEATURES += "alsa usbhost wlan 3dtv switchoff osdposition hdmicec fan"
 
 require conf/machine/include/tune-mips32.inc
 

--- a/conf/machine/include/vuxxo4k.inc
+++ b/conf/machine/include/vuxxo4k.inc
@@ -62,7 +62,7 @@ IMAGE_CMD_tar_prepend = " \
         rm -rf vuplus; \
 "
 
-MACHINE_FEATURES += "alsa usbhost wlan kernelwifi extrakernelwifi 3dtv switchoff osdposition hdmicec"
+MACHINE_FEATURES += "alsa usbhost wlan 3dtv switchoff osdposition hdmicec"
 
 require conf/machine/include/arm/arch-armv7a.inc
 

--- a/conf/machine/vuduo4k.conf
+++ b/conf/machine/vuduo4k.conf
@@ -20,7 +20,7 @@ IMAGE_INSTALL_append += "\
 PREFERRED_VERSION_mmc-utils = "0.2"
 PREFERRED_VERSION_linux-${MACHINE} = "4.1.45"
 
-MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs webkithbbtv ctrlrc colorlcd transcoding streamproxy dvbproxy mmc bluetooth bcmwifi kodi"
+MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs webkithbbtv ctrlrc colorlcd transcoding streamproxy dvbproxy mmc bluetooth bcmwifi kodi hdmi-in-helper"
 
 CHIPSET = "bcm7278"
 

--- a/conf/machine/vuultimo4k.conf
+++ b/conf/machine/vuultimo4k.conf
@@ -17,7 +17,7 @@ IMAGE_INSTALL_append += "\
 	vuplus-wifi-util-${MACHINE} \
 	"
 
-MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs webkithbbtv ctrlrc colorlcd transcoding streamproxy dvbproxy mmc bluetooth bcmwifi kodi chromiumos"
+MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs webkithbbtv ctrlrc colorlcd transcoding streamproxy dvbproxy mmc bluetooth bcmwifi kodi chromiumos hdmi-in-helper"
 
 CHIPSET = "bcm7444"
 

--- a/conf/machine/vuuno4kse.conf
+++ b/conf/machine/vuuno4kse.conf
@@ -16,7 +16,7 @@ IMAGE_INSTALL_append += "\
 	vuplus-bluetooth-util-${MACHINE} \
 "
 
-MACHINE_FEATURES += "dvb-c blindscan-dvbc webkithbbtv ctrlrc colorlcd transcoding streamproxy dvbproxy mmc bluetooth kodi chromiumos"
+MACHINE_FEATURES += "dvb-c blindscan-dvbc webkithbbtv ctrlrc colorlcd transcoding streamproxy dvbproxy mmc bluetooth kodi chromiumos hdmi-in-helper"
 
 CHIPSET = "bcm7252S"
 


### PR DESCRIPTION
-kernelwifi and extrakernelwifi isn't used anymore
-vuplus hdmi helper doesn't have a machine feature yet.