### PR TITLE
fixed Duo 4K built-in wifi

### DIFF
--- a/recipes-bsp/drivers/vuplus-wifi-util-vuduo4k.bb
+++ b/recipes-bsp/drivers/vuplus-wifi-util-vuduo4k.bb
@@ -5,13 +5,17 @@ COMPATIBLE_MACHINE = "^(vuduo4k)$"
 PV="18.1"
 SRCDATE = "20181109"
 SRCDATE_PR = "r0"
-PR_append = ".1"
+PR_append = ".2"
 
 SRC_URI[md5sum] = "2df0715a75c7ff0b85f13f907536bf84"
 SRC_URI[sha256sum] = "a02c58fe339e6d75d7da9ec55d99520dff4838adec0ed60225ff4a85a7e5649d"
 
+inherit update-rc.d
+
+INITSCRIPT_PARAMS = "start 60 S ."
+INITSCRIPT_NAME = "vuplus-wifi-init.sh"
+
 do_install_append() {
-	install -d ${D}${sysconfdir}/mdev
-	install -m 0755 ${S}/bcmwifi_firmware.sh ${D}${sysconfdir}/mdev/
-	install -m 0755 ${S}/bcmwifi_drv.sh ${D}${sysconfdir}/mdev/
+	install -d ${D}${INIT_D_DIR}
+	install -m 0755 ${S}/${INITSCRIPT_NAME} ${D}${INIT_D_DIR}/${INITSCRIPT_NAME}
 }


### PR DESCRIPTION
OpenPLi has switched from mdev to udev, the old solution doesn't work anymore. 
The Duo 4K now has the same solution as the Ultimo 4K.