### PR TITLE
vuxxo2: add dvbproxy to MACHINE_FEATURES

### DIFF
--- a/conf/machine/vuduo2.conf
+++ b/conf/machine/vuduo2.conf
@@ -16,7 +16,7 @@ EXTRA_IMAGEDEPENDS += "\
 	enigma2-plugin-systemplugins-manualfancontrol \
 "
 
-MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv wol ctrlrc transcoding streamproxy opera-browser bwlcd140 SCART RCA YUV"
+MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv wol ctrlrc transcoding streamproxy dvbproxy opera-browser bwlcd140 SCART RCA YUV"
 
 CHIPSET = "bcm7424"
 

--- a/conf/machine/vusolo2.conf
+++ b/conf/machine/vusolo2.conf
@@ -12,7 +12,7 @@ EXTRA_IMAGEDEPENDS += " \
 	enigma2-plugin-systemplugins-manualfancontrol \
 "
 
-MACHINE_FEATURES += "textlcd hbbtv transcoding streamproxy blindscan-dvbs ctrlrc opera-browser SCART RCA"
+MACHINE_FEATURES += "textlcd hbbtv transcoding streamproxy dvbproxy blindscan-dvbs ctrlrc opera-browser SCART RCA"
 
 CHIPSET = "bcm7356"
 

--- a/conf/machine/vusolose.conf
+++ b/conf/machine/vusolose.conf
@@ -10,7 +10,7 @@ IMAGE_INSTALL_append += "\
 	vuplus-initrd-${MACHINE} \
 "
 
-MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv ctrlrc vupluszap transcoding streamproxy opera-browser RCA"
+MACHINE_FEATURES += "dvb-c blindscan-dvbc blindscan-dvbs hbbtv ctrlrc vupluszap transcoding streamproxy dvbproxy opera-browser RCA"
 
 CHIPSET = "bcm7241"
 


### PR DESCRIPTION
Switch to dvbproxy drivers providing GLES.
This is needed basically only by kodi_18 at the moment.

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>