### PR TITLE
xbmc-support-vuxxo2: add vuxxo2 packages for kodi_18

### DIFF
--- a/recipes-multimedia/kodi/xbmc-support-vuduo2.bb
+++ b/recipes-multimedia/kodi/xbmc-support-vuduo2.bb
@@ -1,0 +1,10 @@
+require xbmc-support.inc
+
+COMPATIBLE_MACHINE = "^(vuduo2)$"
+
+PV = "1.0"
+
+GLPR = "20160331_r0"
+
+SRC_URI[md5sum] = "f3db678550f3654fcc8dfbb875678943"
+SRC_URI[sha256sum] = "758e75966c1ca513bbeb7eaef0d0359207232ba0e7f4f5e2574c146f5e09cab3"

--- a/recipes-multimedia/kodi/xbmc-support-vusolo2.bb
+++ b/recipes-multimedia/kodi/xbmc-support-vusolo2.bb
@@ -1,0 +1,10 @@
+require xbmc-support.inc
+
+COMPATIBLE_MACHINE = "^(vusolo2)$"
+
+PV = "1.0"
+
+GLPR = "20160331_r0"
+
+SRC_URI[md5sum] = "e29a91b185133ec60a59e94a8229d2b4"
+SRC_URI[sha256sum] = "3c56b7ee890b3e21f378acd79db3752d721de0880b6d763bbd37fa942c2ae2b5"

--- a/recipes-multimedia/kodi/xbmc-support-vusolose.bbb
+++ b/recipes-multimedia/kodi/xbmc-support-vusolose.bbb
@@ -1,0 +1,10 @@
+require xbmc-support.inc
+
+COMPATIBLE_MACHINE = "^(vusolose)$"
+
+PV = "1.0"
+
+GLPR = "20160331_r0"
+
+SRC_URI[md5sum] = "831014212eed47e36ec084f2e803e2d8"
+SRC_URI[sha256sum] = "97bfc26a316bcba4b897f81f31179e8861cc123a0b4d8589a2290f3cd7268c1d"

--- a/recipes-multimedia/kodi/xbmc-support.inc
+++ b/recipes-multimedia/kodi/xbmc-support.inc
@@ -1,0 +1,28 @@
+SECTION = "base"
+LICENSE = "CLOSED"
+
+PR = "${GLPR}"
+
+DEPENDS = "virtual/libgles2 virtual/egl"
+
+SRC_URI = "http://archive.vuplus.com/download/build_support/kodi/xbmc-support_${MACHINE}_${GLPR}.tar.gz"
+
+# The driver is a set of binary libraries to install
+# there is nothing to configure or compile
+do_configure[noexec] = "1"
+
+do_install(){
+    install -d ${D}${libdir}
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/xbmc-support/xbmc.helper ${D}${bindir}
+    install -m 0755 ${WORKDIR}/xbmc-support/libxbmc_base.so ${D}${libdir}
+}
+
+FILES_SOLIBSDEV = ""
+FILES_${PN} = "${bindir}/xbmc.helper ${libdir}/libxbmc_base.so"
+
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
import from meta-openpli with stylistic changes to adapt to the BSP

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>