### PR TITLE
[vuplus] bcm wifi fix white space ssid name

### DIFF
--- a/recipes-bsp/drivers/vuplus-wifi-util.inc
+++ b/recipes-bsp/drivers/vuplus-wifi-util.inc
@@ -26,6 +26,7 @@ do_install() {
 	install -m 0755 ${S}/wl ${D}${bindir}
 	install -m 0755 ${S}/wl-config.sh ${D}${bindir}
 	install -m 0755 ${S}/wl-down.sh ${D}${bindir}
+	sed  's!wl ssid $SSID!wl ssid "$SSID"!' -i ${D}${bindir}/wl-config.sh
 
 	install -d ${D}/usr/local/modules
 	install -m 0644 ${S}/dhd.ko ${D}/usr/local/modules/dhd.ko


### PR DESCRIPTION
https://github.com/oe-alliance/oe-alliance-core/commit/f26cba872c06e3111001f9397473e0de505f487c