### PR TITLE
linux-vuplus-3.x: extend gcc-4.9.3 patches to allow build with musl libc

### DIFF
--- a/recipes-bsp/linux/linux-vuplus-3.13.5/linux-3.13-gcc-4.9.3-build-error-fixed.patch
+++ b/recipes-bsp/linux/linux-vuplus-3.13.5/linux-3.13-gcc-4.9.3-build-error-fixed.patch
@@ -6,7 +6,7 @@ index de300b9..6ba647b 100644
  endif
  cflags-y += $(call cc-option, -mno-check-zero-division)
  
-+GCC_VERSION = $(shell $(CC) --version | grep ^mipsel-oe-linux-gcc | sed 's/^.* //g' | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/')
++GCC_VERSION = $(shell $(CC) --version | grep -e ^mipsel-oe-linux-gcc -e ^mipsel-oe-linux-musl-gcc | sed 's/^.* //g' | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/')
 +GCC_GTEQ_493 = $(shell expr $(GCC_VERSION) \>= 40903)
 +ifeq ($(GCC_GTEQ_493),1)
 +  # oskwon fixed.

--- a/recipes-bsp/linux/linux-vuplus-3.9.6/linux-3.9-gcc-4.9.3-build-error-fixed.patch
+++ b/recipes-bsp/linux/linux-vuplus-3.9.6/linux-3.9-gcc-4.9.3-build-error-fixed.patch
@@ -6,7 +6,7 @@ index 6f7978f..446a039 100644
  endif
  cflags-y += $(call cc-option, -mno-check-zero-division)
  
-+GCC_VERSION = $(shell $(CC) --version | grep ^mipsel-oe-linux-gcc | sed 's/^.* //g' | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/')
++GCC_VERSION = $(shell $(CC) --version | grep -e ^mipsel-oe-linux-gcc -e ^mipsel-oe-linux-musl-gcc | sed 's/^.* //g' | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/')
 +GCC_GTEQ_493 = $(shell expr $(GCC_VERSION) \>= 40903)
 +ifeq ($(GCC_GTEQ_493),1)
 +  # oskwon fixed.


### PR DESCRIPTION
Signed-off-by: Andrea Adami <andrea.adami@gmail.com>